### PR TITLE
em-odp v2.2.0

### DIFF
--- a/CHANGE_NOTES
+++ b/CHANGE_NOTES
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2019, Nokia Solutions and Networks
+Copyright (c) 2013-2020, Nokia Solutions and Networks
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -44,9 +44,65 @@ The version numbering scheme reflects the used EM API version:
 - See em-odp/include/event_machine/README_API for API changes
 
 --------------------------------------------------------------------------------
+Event Machine on ODP v2.2.0
+--------------------------------------------------------------------------------
+- Support for EM API v2.2 (em-odp/include), see API changes in
+  em-odp/include/event_machine/README_API.
+- EM config file options - config/em-odp.conf
+    - Option 'pool.align_offset':
+      (Replaced 'pool.alloc_align' with 'pool.align_offset')
+
+      Alignment offset in bytes for the event payload start address.
+      Set the event payload alignment offset for events allocated from
+      any pool. This is a global setting concerning all pools.
+      A similar, but pool-secific option, is 'em_pool_cfg_t:align_offset{}'
+      that overrides this global setting for a specific pool when given to
+      em_pool_create(..., pool_cfg).
+
+      Use this option to globally adjust the payload layout so that a
+      specific part of it can be placed at a needed alignment for e.g.
+      HW access.
+
+      The default EM event payload start address alignment is a power-of-two
+      that is at minimum 32 bytes (i.e. 32 B, 64 B, 128 B etc. depending on
+      e.g. target cache-line size).
+      The 'align_offset' option can be used to fine-tune the start-address
+      by a small offset to e.g. make room for a small SW header before the
+      rest of the payload that might need a specific alignment for direct
+      HW-access.
+      Example: setting 'align_offset = 8' makes sure that the payload
+      _after_ 8 bytes will be aligned at minimum (2^x) 32 bytes for all
+      pools that do not override this value.
+
+      start: base - align_offset
+           |
+           v
+           +------------------------------------------+
+           | <----- |  Event Payload                  |
+           +------------------------------------------+
+                    ^
+                    |
+                   base (min 32B aligned, power-of-two)
+- New autoconf configure-script options (configure.ac):
+    --without-programs
+      Build the EM library without example programs
+    --with-config-file=FILE
+      Override the default EM configuration file (default:config/em-odp.conf)
+      that is used during the configure & build phases to generate the built-in
+      default values for the EM runtime-config (note that runtime config options
+      can further be changed during startup by setting the EM_CONFIG_FILE=file
+      variable).
+      The overriding file set with --with-config-file=FILE must include all
+      EM configuration options (unlike the runtime file that only need to
+      include the mandatory and changed options).
+    --enable-check-level=VAL(0…3)
+      Set the compile-time EM_CHECK_LEVEL,
+      see include/event_machine/platform/event_machine_config.h
+
+--------------------------------------------------------------------------------
 Event Machine on ODP v2.1.2
 --------------------------------------------------------------------------------
-- Config file options - config/em-odp.conf
+- EM config file options - config/em-odp.conf
   EM runtime configuration options added. The user can optionally override
   default config options by setting the environmental variable 'EM_CONFIG_FILE'
   to point to an alternative config file with desired values, e.g.:
@@ -64,7 +120,7 @@ Event Machine on ODP v2.1.2
       thus, if enabled, inducing some overhead. Pool information can be
       obtained by calling em_pool_info() and, if pool usage statistics is
       enabled, will return also pool usage statistics.
-    - Option 'pool.alloc_align':
+    - Option 'pool.alloc_align': (changed to 'pool.align_offset' in v2.2.0)
       Alloc alignment in bytes, default = 0 (no extra alignment requirement)
       Set the exact alignment of the event payload start address (in bytes).
       The event payload address returned by em_event_pointer(event) will

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,10 @@
 ACLOCAL_AMFLAGS=-I m4
 AUTOMAKE_OPTIONS = foreign
-SUBDIRS = src programs
+SUBDIRS = src
+
+if WITH_PROGRAMS
+  SUBDIRS += programs
+endif
 
 if HAVE_PKGCONFIG
   SUBDIRS += pkgconfig

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2019, Nokia Solutions and Networks
+Copyright (c) 2013-2020, Nokia Solutions and Networks
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -52,13 +52,14 @@ If testing for performance, also give the --disable-abi-compat option to enable
 more inlining of code. Try also --disable-shared if a static lib is OK for you.
 (> ../configure --prefix=<odp install path> --disable-abi-compat \
    --disable-shared)
+See further configure options: ../configure --help
 > make && make install
 
-Tested against odp commit (at the time of writing the latest commit on the
-odp git master branch):
-  Commit: 2f226e691e6b208f662f0573d100f3300fd94161 [2f226e6]
-  Commit Date: Tuesday, 17 March 2020 15:05.56
-  validation: pool: add test for packet pool seg_len parameter
+Tested against odp linux-generic, commit:
+  Commit: fd9f805a0024677f31876e13d28aa8ab9470a282 [fd9f805]
+  Date: Thursday, 4 June 2020 0:48.15
+  Commit Date: Thursday, 4 June 2020 16:39.27
+  validation: classification: fix duplicate global variable definition
 
 Trying to build static test applications without a static ODP library would
 fail.
@@ -72,10 +73,16 @@ em-odp with different odp installations or configurations.
 > ./bootstrap
 > mkdir build && cd build
 > ../configure --prefix=<em-odp install path> --with-odp-path=<odp install path>
+See further configure options: ../configure --help
 > make && make install
 
 Run some example application to test the functionality (path from build/), e.g.
 > ./programs/example/fractal/fractal -c 0xe -t
+Optionally change ODP and/or EM run-time options by specifying your own
+runtime config files:
+> ODP_CONFIG_FILE=my-odp.conf EM_CONFIG_FILE=my-em.conf \
+  ./programs/example/hello/hello -c 0xe -t
+
 Stop by pressing Ctrl-C.
 
 ===============================================================================
@@ -154,11 +161,11 @@ to configure and compile dpdk and odp-dpdk on top of it.
 ODP compilations as above but different installation directories i.e.
 > ../configure --prefix=<odp-dpdk install path>
 
-Tested against odp-dpdk v1.23.0.0_DPDK_18.11 (at the time of writing the
-latest on the odp-dpdk git master branch):
-  Commit: 4f6d7f4a897808865b6a4da37fd17837b5b5453f [4f6d7f4]
-  Date: Tuesday, 3 December 2019 8:57.13
-  Merge pull request #83
+Tested against odp-dpdk commit:
+Commit: 102173c31bf1af979488af3d3d4175d162ac0454 [102173c]
+Date: Monday, 11 May 2020 14:59.08
+Commit Date: Wednesday, 13 May 2020 12:30.53
+linux-dpdk: pktio: add configuration option for ethernet multicast receipt
 
 EM-ODP compilation with odp-dpdk:
 > mkdir build-dpdk && cd build-dpdk

--- a/config/em-odp.conf
+++ b/config/em-odp.conf
@@ -1,12 +1,14 @@
 # EM runtime configuration options
 #
 # This template configuration file (em-odp.conf) is hardcoded
-# during configure/build phase and the values defined here are used if
-# optional EM_CONFIG_FILE is not set. This configuration file MUST
-# include all configuration options.
+# during the configure/build phase into em-odp and the values defined here are
+# used at runtime unless overridden by the user with the optional environment
+# variable EM_CONFIG_FILE=my-emodp.conf at program startup.
 #
-# EM_CONFIG_FILE can be used to override default values and it doesn't
-# have to include all available options. The missing options are
+# This configuration file MUST include all configuration options.
+#
+# The environment variable EM_CONFIG_FILE can be used to override default values
+# and it doesn't have to include all available options. The missing options are
 # replaced with hardcoded default values.
 #
 # The options defined here are implementation specific and valid option
@@ -14,7 +16,7 @@
 
 # Mandatory fields
 em_implementation = "em-odp"
-config_file_version = "0.0.5"
+config_file_version = "0.0.6"
 
 # Pool options
 pool: {
@@ -26,13 +28,39 @@ pool: {
 	# enabled, will return also pool usage statistics.
 	statistics_enable = false
 
-	# Alloc alignment in bytes, default = 0 (no extra alignment requirement)
+	# Alignment offset in bytes for the event payload start address
 	#
-	# Set the exact alignment of the event payload start address (in bytes).
-	# The event payload address returned by em_event_pointer(event) will
-	# have the this alignment. Use power of two values only.
+	# Set the event payload alignment offset for events allocated from
+	# any pool. This is a global setting concerning all pools.
+	# A similar, but pool-secific option, is 'em_pool_cfg_t:align_offset{}'
+	# that overrides this global setting for a specific pool when given to
+	# em_pool_create(..., pool_cfg).
 	#
-	alloc_align = 0
+	# Use this option to globally adjust the payload layout so that a
+	# specific part of it can be placed at a needed alignment for e.g.
+	# HW access.
+	#
+	# The default EM event payload start address alignment is a power-of-two
+	# that is at minimum 32 bytes (i.e. 32 B, 64 B, 128 B etc. depending on
+	# e.g. target cache-line size).
+	# The 'align_offset' option can be used to fine-tune the start-address
+	# by a small offset to e.g. make room for a small SW header before the
+	# rest of the payload that might need a specific alignment for direct
+	# HW-access.
+	# Example: setting 'align_offset = 8' makes sure that the payload
+	# _after_ 8 bytes will be aligned at minimum (2^x) 32 bytes for all
+	# pools that do not override this value.
+	#
+	#   start: base - align_offset
+	#        |
+	#        v
+	#        +------------------------------------------+
+	#        | <----- |  Event Payload                  |
+	#        +------------------------------------------+
+	#                 ^
+	#                 |
+	#                base (min 32B aligned, power-of-two)
+	align_offset = 0
 }
 
 # Queue options

--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,10 @@
-#                                               -*- Autoconf -*-
-# Process this file with autoconf to produce a configure script.
-
 AC_PREREQ([2.69])
 ############################
 # Version
 ############################
 m4_define([em_api_major_version], [2])
-m4_define([em_api_minor_version], [1])
-m4_define([em_api_implementation_version], [2])
+m4_define([em_api_minor_version], [2])
+m4_define([em_api_implementation_version], [0])
 m4_define([em_api_implementation_fix], [0])
 
 m4_define([em_api_version], [em_api_major_version.em_api_minor_version])
@@ -17,8 +14,17 @@ m4_define([em_version], [m4_if(m4_eval(em_api_implementation_fix), [0],
 
 m4_define([em_lib_version], m4_join([], em_api_major_version, em_api_minor_version))
 m4_if(em_api_implementation_fix, [0],
-      [m4_append([em_lib_version], m4_combine([], [[]], [:], em_api_implementation_version, [0]))],
-      [m4_append([em_lib_version], m4_combine([], [[]], [:], em_api_implementation_version, em_api_implementation_fix))])
+      [m4_append([em_lib_version],
+		 m4_combine([], [[]], [:], em_api_implementation_version, [0]))],
+      [m4_append([em_lib_version],
+		 m4_combine([], [[]], [:], em_api_implementation_version, em_api_implementation_fix))])
+
+m4_define([em_pkgconfig_version], m4_join([], em_api_major_version, em_api_minor_version))
+m4_if(em_api_implementation_fix, [0],
+      [m4_append([em_pkgconfig_version],
+		 m4_combine([], [[]], [.], em_api_implementation_version, [0]))],
+      [m4_append([em_pkgconfig_version],
+		 m4_combine([], [[]], [.], em_api_implementation_version, em_api_implementation_fix))])
 
 AC_INIT([EM-ODP],[em_version],[foo at nokia.com])
 
@@ -33,7 +39,13 @@ EM_API_VERSION=em_api_version
 AC_SUBST(EM_API_VERSION)
 
 EM_VERSION=em_version
-AC_SUBST(EMODP_VERSION)
+AC_SUBST(EM_VERSION)
+
+##########################################################################
+# Test if user has set CFLAGS. Automake initializes CFLAGS to "-g -O2"
+# by default.
+##########################################################################
+AS_IF([test "$ac_cv_env_CFLAGS_set" = ""], [user_cflags=0], [user_cflags=1])
 
 AM_INIT_AUTOMAKE([subdir-objects -Wall -Werror])
 AC_CONFIG_SRCDIR([include/event_machine.h])
@@ -49,6 +61,9 @@ AM_SILENT_RULES([yes])
 ############################
 EMODP_LIBSO_VERSION=em_lib_version
 AC_SUBST(EMODP_LIBSO_VERSION)
+
+EMODP_PKGCONFIG_VERSION=em_pkgconfig_version
+AC_SUBST(EMODP_PKGCONFIG_VERSION)
 
 # Checks for programs.
 AC_PROG_CXX
@@ -78,17 +93,32 @@ AC_TYPE_UINT64_T
 ##########################################################################
 # Check for pthreads availability
 ##########################################################################
+EM_PTHREAD
 
-EM_PTHREAD([], [echo "Error! We require pthreads to be available"
-		exit -1])
 LIBS="$PTHREAD_LIBS $LIBS"
 AM_CFLAGS="$AM_CFLAGS $PTHREAD_CFLAGS"
-AM_LDFLAGS="$AM_LDFLAGS $PTHREAD_LDFLAGS"
 CC="$PTHREAD_CC"
 
 AC_SEARCH_LIBS([timer_create],[rt posix4])
 
-EM_LIBCONFIG([])
+##########################################################################
+# EM configuration file
+##########################################################################
+# Default EM configuration file
+default_config_path="${srcdir}/config/em-odp.conf"
+
+# Set optional path for the default configuration file,
+# i.e. override the file to be used for generating the built-in default
+# EM configuration.
+# Note that values set in the run-time config file, if given at startup, will
+# overide the corresponding built-in config file values.
+AC_ARG_WITH([config-file],
+	    [AS_HELP_STRING([--with-config-file=FILE],
+			    [Override the default EM configuration file
+			    (file must include all EM configuration options)])],
+	    [default_config_path=$withval], [])
+
+EM_LIBCONFIG([$default_config_path])
 
 ##########################################################################
 # Default warning setup
@@ -115,6 +145,41 @@ EM_CFLAGS="$EM_CFLAGS -std=c99"
 EM_CFLAGS="$EM_CFLAGS $EM_CFLAGS_EXTRA"
 
 EM_CPPFLAGS="$EM_CPPFLAGS -DENV_64_BIT -DEM_64_BIT"
+
+##########################################################################
+# EM (em-odp) compile-time options
+##########################################################################
+
+# Override the EM-define value 'EM_CHECK_LEVEL' to 0...3 (yes=3)
+# --enable-check-level=0...3     Set 'EM_CHECK_LEVEL' to the given
+#                                value 0...3
+# --enable-check-level=yes (=3)  Set 'EM_CHECK_LEVEL' to 3
+# --enable-check-level           Set 'EM_CHECK_LEVEL' to 3
+# --disable-check-level or
+#   no option given              Use '#define EM_CHECK_LEVEL 0...3' from
+#                                source code
+check_level_info="no (EM_CHECK_LEVEL from source code)"
+EM_CHECK_LEVEL=""
+AC_ARG_ENABLE([check-level],
+	      [AS_HELP_STRING([--enable-check-level[[=VAL]]],
+			      [Override the 'EM_CHECK_LEVEL' define, valid
+			       values are 0...3, yes(=3) or no value(=3)
+			       [default=yes=3]])],
+	      [AS_IF([test "$enableval" -ge 0 -a "$enableval" -le 3 2>/dev/null],
+		     [check_level_info="yes:$enableval (EM_CHECK_LEVEL)"
+		      EM_CHECK_LEVEL="-DEM_CHECK_LEVEL=$enableval"],
+
+		     [test "x$enableval" = "xyes"],
+		     [check_level_info="yes:3 (EM_CHECK_LEVEL)"
+		      EM_CHECK_LEVEL="-DEM_CHECK_LEVEL=3"],
+
+		     [test "x$enableval" != "xno"],
+		     [AC_MSG_ERROR([bad value ${enableval} for --enable-check-level])]
+		)
+		EM_CPPFLAGS="$EM_CPPFLAGS $EM_CHECK_LEVEL"
+	      ],[])
+# Substitute @EM_CHECK_LEVEL@ into the pkgconfig file libemodp.pc.in
+AC_SUBST(EM_CHECK_LEVEL)
 
 ##########################################################################
 # Default include setup
@@ -157,11 +222,9 @@ AS_CASE([$host],
 )
 AC_SUBST([ARCH_ABI])
 
-if test "${ARCH_ABI}" == "undefined";
-then
-	echo "ARCH_ABI is undefined, please add your ARCH_ABI based on host=${host}"
-	exit 1
-fi
+AS_IF([test "${ARCH_ABI}" == "undefined"],
+      [AC_MSG_ERROR([ARCH_ABI is undefined,
+		     please add your ARCH_ABI based on host=${host}])])
 
 ##########################################################################
 # Enable/disable ABI compatible build
@@ -169,18 +232,18 @@ fi
 EM_ABI_COMPAT=1
 abi_compat=yes
 AC_ARG_ENABLE([abi-compat],
-	[AS_HELP_STRING([--disable-abi-compat],
-			[disables ABI compatible mode])],
-	[if test "x$enableval" = "xno"; then
-		EM_ABI_COMPAT=0
-		abi_compat=no
-		# do not try -march=native for clang due to possible failures on
-		# clang optimizations
-		$CC --version | grep -q clang
-		if test $? -ne 0 -a $user_cflags -eq 0; then
-			EM_CHECK_CFLAG([-march=native])
-		fi
-	fi])
+	      [AS_HELP_STRING([--disable-abi-compat],
+			      [disables ABI compatible mode])],
+	      [AS_IF([test "x$enableval" = "xno"],
+		     [EM_ABI_COMPAT=0
+		      abi_compat=no
+		      # do not try -march=native for clang due to possible
+		      # failures on clang optimizations
+		      $CC --version | grep -q clang
+		      AS_IF([test $? -ne 0 -a "$user_cflags" -eq 0],
+			    [EM_CHECK_CFLAG([-march=native])])
+		     ])
+	      ])
 AM_CONDITIONAL(EM_ABI_COMPAT, [test "x$EM_ABI_COMPAT" = "x1"])
 
 ##########################################################################
@@ -188,15 +251,17 @@ AM_CONDITIONAL(EM_ABI_COMPAT, [test "x$EM_ABI_COMPAT" = "x1"])
 ##########################################################################
 lto_enabled=no
 AC_ARG_ENABLE([lto],
-	[AS_HELP_STRING([--enable-lto],
-			[Enable Link Time Optimization (LTO) in compiler and linker])],
-	[if test "x$enableval" = "xyes"; then
-		lto_enabled=yes
-		# Fat LTO object file contains GIMPLE bytecodes and the usual
-		# final code. There are less build problems (e.g. due to older
-		# binutils), but object files are larger.
-		EM_LTO_FLAGS="-flto -ffat-lto-objects"
-	fi])
+	      [AS_HELP_STRING([--enable-lto],
+			      [Enable Link Time Optimization (LTO)
+			       in compiler and linker])],
+	      [AS_IF([test "x$enableval" = "xyes"],
+		     [lto_enabled=yes
+		      # Fat LTO object file contains GIMPLE bytecodes and the
+		      # usual final code. There are less build problems (e.g.
+		      # due to older binutils), but object files are larger.
+		      EM_LTO_FLAGS="-flto -ffat-lto-objects"
+		     ])
+	      ])
 AC_SUBST(EM_LTO_FLAGS)
 AM_CFLAGS="$AM_CFLAGS $EM_LTO_FLAGS"
 AM_LDFLAGS="$AM_LDFLAGS $EM_LTO_FLAGS"
@@ -206,26 +271,34 @@ AM_LDFLAGS="$AM_LDFLAGS $EM_LTO_FLAGS"
 ##########################################################################
 # Optional configure parameter for a non-standard install prefix of ODP
 AC_ARG_WITH([odp-path],
-	[AS_HELP_STRING([--with-odp-path=prefix],
-			[non-standard install prefix of odp])],
-	[# extend the compiler and linker flags according to the path set
-	 AM_CPPFLAGS="$AM_CPPFLAGS -I$with_odp_path/include"
-	 AM_CPPFLAGS="$AM_CPPFLAGS -I$with_odp_path/include/odp/arch/$ARCH_ABI"
-	 AM_LDFLAGS="$AM_LDFLAGS -L$with_odp_path/lib"
-	 export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$with_odp_path/lib/pkgconfig"],
-	[])
+	    [AS_HELP_STRING([--with-odp-path=prefix],
+			    [non-standard install prefix of odp])],
+	    [# extend the compiler and linker flags according to the path set
+	     AM_CPPFLAGS="$AM_CPPFLAGS -I$with_odp_path/include"
+	     AM_CPPFLAGS="$AM_CPPFLAGS -I$with_odp_path/include/odp/arch/$ARCH_ABI"
+	     AM_LDFLAGS="$AM_LDFLAGS -L$with_odp_path/lib"
+	     export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$with_odp_path/lib/pkgconfig"],
+	    [])
+
+##########################################################################
+# Build without example programs
+##########################################################################
+AC_ARG_WITH([programs],
+	    [AS_HELP_STRING([--without-programs],
+			    [build without example programs])],
+	    [],
+	    [with_programs=yes])
+AM_CONDITIONAL([WITH_PROGRAMS], [test x$with_programs != xno])
 
 ##########################################################################
 # Get configuration from libodp-linux.pc with pkg-config
 ##########################################################################
 AC_CHECK_PROGS([PKGCONFIG], [pkg-config])
-if test -z "$PKGCONFIG"; then
-	AC_MSG_ERROR([Please install pkg-config])
-fi
+AS_IF([test -z "$PKGCONFIG"],
+      [AC_MSG_ERROR([Please install pkg-config])])
 
-if test "x$enable_static" = "xyes" ; then
-	export PKG_CONFIG="pkg-config --static"
-fi
+AS_IF([test "x$enable_static" = "xyes"],
+      [export PKG_CONFIG="pkg-config --static"])
 
 PKG_CHECK_MODULES([ODP], [libodp-linux])
 AC_SUBST([ODP_CFLAGS])
@@ -248,20 +321,18 @@ AM_COND_IF([HAVE_PKGCONFIG], [AC_CONFIG_FILES([pkgconfig/libemodp.pc])])
 # Doxygen Configuration
 ##########################################################################
 AC_CHECK_PROGS([DOXYGEN], [doxygen])
-if test -z "$DOXYGEN"; then
-	AC_MSG_WARN([Doxygen not found - continue without Doxygen support])
-fi
+AS_IF([test -z "$DOXYGEN"],
+      [AC_MSG_WARN([Doxygen not found - continue without Doxygen support])])
 
 AM_CONDITIONAL([HAVE_DOXYGEN], [test -n "$DOXYGEN"])
 
-if test "x$enable_doxygen" != "xno"; then
-	DX_HTML_FEATURE(ON)
-	DX_PDF_FEATURE(OFF)
-	DX_PS_FEATURE(OFF)
-
-	DX_INIT_DOXYGEN($PACKAGE, ${srcdir}/doc/Doxyfile, ${builddir}/doc/event_machine_api)
-	AM_COND_IF([HAVE_DOXYGEN], [AC_CONFIG_FILES([doc/Makefile])])
-fi
+AS_IF([test "x$enable_doxygen" != "xno"],
+      [DX_HTML_FEATURE(ON)
+       DX_PDF_FEATURE(OFF)
+       DX_PS_FEATURE(OFF)
+       DX_INIT_DOXYGEN($PACKAGE, ${srcdir}/doc/Doxyfile, ${builddir}/doc/event_machine_api)
+       AM_COND_IF([HAVE_DOXYGEN], [AC_CONFIG_FILES([doc/Makefile])])
+      ])
 
 ##########################################################################
 # distribute the changed variables among the Makefiles
@@ -303,10 +374,18 @@ AC_MSG_RESULT([
 	cflags:			${CFLAGS}
 	am_cflags:		${AM_CFLAGS}
 	am_cxxflags:		${AM_CXXFLAGS}
+	ld:			${LD}
 	ldflags:		${LDFLAGS}
 	am_ldflags:		${AM_LDFLAGS}
+	libs:			${LIBS}
+	defs:			${DEFS}
 	static libraries:	${enable_static}
 	shared libraries:	${enable_shared}
 	ABI compatible:		${abi_compat}
 	link time optimization:	${lto_enabled}
+	example programs:	${with_programs}
+
+	EM Compile Time Options
+	=======================
+	EM check level:		${check_level_info}
 	])

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1012,7 +1012,7 @@ INLINE_SOURCES         = NO
 # Fortran comments will always remain visible.
 # The default value is: YES.
 
-STRIP_CODE_COMMENTS    = YES
+STRIP_CODE_COMMENTS    = NO
 
 # If the REFERENCED_BY_RELATION tag is set to YES then for each documented
 # function all documented functions referencing it will be listed.

--- a/include/event_machine.h
+++ b/include/event_machine.h
@@ -53,7 +53,7 @@ extern "C" {
  * Minor API version number.
  * Updates and additions
  */
-#define EM_API_VERSION_MINOR 1
+#define EM_API_VERSION_MINOR 2
 
 /** @mainpage
  *

--- a/include/event_machine/LICENSE
+++ b/include/event_machine/LICENSE
@@ -1,7 +1,7 @@
 License: BSD-3-Clause
 /*
  *   Copyright (c) 2012, Nokia Siemens Networks
- *   Copyright (c) 2013-2019, Nokia Solutions and Networks
+ *   Copyright (c) 2013-2020, Nokia Solutions and Networks
  *   All rights reserved.
  *
  *   Redistribution and use in source and binary forms, with or without

--- a/include/event_machine/README_API
+++ b/include/event_machine/README_API
@@ -3,11 +3,33 @@ OpenEM API Release Notes
 -------------------------------------------------------------------------------
 
 -------------------------------------------------------------------------------
+API 2.2 (EM_API_VERSION_MAJOR=2, EM_API_VERSION_MINOR=2)
+-------------------------------------------------------------------------------
+  Backwards compatible with EM 2.1 API with one EXCEPTION:
+  Introducing the new 'em_pool_cfg_t::align_offset{}' option into the existing
+  em_pool_conf_t structure is potentially dangerous if these new fields are not
+  initialized properly. Initializing the whole em_pool_cfg_t to '0' with memset
+  before use is safe and equals API 2.1 behaviour.
+
+1. Pool option to set the event payload alignment offset:
+   Add the new 'em_pool_cfg_t::align_offset{}' option to be able to set the
+   needed payload alignment offset per pool (during EM pool creation with
+   em_pool_create(..., pool_cfg)).
+   Setting 'align_offset.in_use = 0' disables the pool-specific alignment offset
+   and equals API 2.1 behaviour.
+   See the documentation for em_pool_cfg_t for a thorough explanation.
+2. Timer option to use an external timer clock source:
+   Add the em_timer_clksrc_t::EM_TIMER_CLKSRC_EXT option.
+   Also add the EM_TIMER_CLKSRC_CPU option to explicitly request using the
+   CPU clock as the timer clock source (behaviour is the same as using
+   EM_TIMER_CLKSRC_DEFAULT).
+
+-------------------------------------------------------------------------------
 API 2.1 (EM_API_VERSION_MAJOR=2, EM_API_VERSION_MINOR=1)
 -------------------------------------------------------------------------------
-  Backwards compatible with EM 2.0 API as long as all fields of em_conf_t given
-  to em_init() is intialized properly (inludes the new em_conf_t::api_hooks
-  field).
+  Backwards compatible with EM 2.0 API with one EXCEPTION:
+  All fields of em_conf_t given to em_init() should be intialized properly
+  (inludes the new em_conf_t::api_hooks field).
 
  1. EO-start buffering of sent events changed to apply only to scheduled queues:
     Events sent to scheduled queues from an EO-start function are buffered.

--- a/include/event_machine/add-ons/event_machine_timer.h
+++ b/include/event_machine/add-ons/event_machine_timer.h
@@ -308,7 +308,7 @@ em_tmo_t em_tmo_create(em_timer_t tmr, em_tmo_flag_t flags, em_queue_t queue);
  *
  * Free (destroy) a timeout.
  * The user provided timeout event for an active timeout will be returned via
- * cur_event and the timer is cancelled. The timeout event for an expired, but
+ * cur_event and the timeout is cancelled. The timeout event for an expired, but
  * not yet received timeout, will not be returned. It is the responsibility of
  * the application to handle that case.
  *
@@ -382,9 +382,9 @@ em_status_t em_tmo_set_rel(em_tmo_t tmo, em_timer_tick_t ticks_rel,
  * Cancel a timeout
  *
  * Cancels a timeout, preventing future expiration. Returns the timeout event,
- * given to em_tmo_set_abs/rel(), in case the timer is still active.
+ * given to em_tmo_set_abs/rel(), in case the timeout is still active.
  *
- * A timer that has already expired cannot be cancelled and the timeout
+ * A timeout that has already expired cannot be cancelled and the timeout event
  * will be delivered to the destination queue. In this case, cancel will return
  * an error as it was too late to cancel. Cancel also fails if attempted before
  * timeout activation.

--- a/include/event_machine/add-ons/templates/event_machine_timer_hw_specific.h.template
+++ b/include/event_machine/add-ons/templates/event_machine_timer_hw_specific.h.template
@@ -81,14 +81,20 @@ typedef enum em_tmo_flag_t {
 } em_tmo_flag_t;
 
 /*
- * em_timer_clksrc_t is used to select the source of clock.
+ * em_timer_clksrc_t is used to select the timer clock source.
+ *
  * EM_TIMER_CLKSRC_DEFAULT is a standard definition, but more can be declared.
- * For instance default could use CPU internal timer and another value for a
- * separate timer running out of an external clock/trigger with different
- * resolution.
+ * The default clock source could e.g. use the CPU internal timer and another
+ * value for a separate timer running out of an external clock/trigger with
+ * different resolution.
  */
 typedef enum em_timer_clksrc_t {
-	EM_TIMER_CLKSRC_DEFAULT = 0	/**< portable default */
+	/** Portable default clock source */
+	EM_TIMER_CLKSRC_DEFAULT = 0,
+	/** CPU clock as clock source */
+	EM_TIMER_CLKSRC_CPU  = 1,
+	/** External clock source */
+	EM_TIMER_CLKSRC_EXT = 2
 } em_timer_clksrc_t;
 
 /**

--- a/include/event_machine/platform/add-ons/event_machine_timer_hw_specific.h
+++ b/include/event_machine/platform/add-ons/event_machine_timer_hw_specific.h
@@ -80,15 +80,20 @@ typedef enum em_tmo_flag_t {
 } em_tmo_flag_t;
 
 /*
- * em_timer_clksrc_t is used to select the clock source.
+ * em_timer_clksrc_t is used to select the timer clock source.
+ *
  * EM_TIMER_CLKSRC_DEFAULT is a standard definition, but more can be declared.
  * The default clock source could e.g. use the CPU internal timer and another
  * value for a separate timer running out of an external clock/trigger with
  * different resolution.
  */
 typedef enum em_timer_clksrc_t {
-	/**< portable default clock source */
-	EM_TIMER_CLKSRC_DEFAULT = 0
+	/** Portable default clock source */
+	EM_TIMER_CLKSRC_DEFAULT = 0,
+	/** CPU clock as clock source */
+	EM_TIMER_CLKSRC_CPU  = 1,
+	/** External clock source */
+	EM_TIMER_CLKSRC_EXT = 2
 } em_timer_clksrc_t;
 
 /**

--- a/include/event_machine/platform/env/env_time.h
+++ b/include/event_machine/platform/env/env_time.h
@@ -1,0 +1,190 @@
+/*
+ *   Copyright (c) 2020, Nokia Solutions and Networks
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * Env time functions.
+ *
+ */
+
+#ifndef _ENV_TIME_H_
+#define _ENV_TIME_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* type for time stamp */
+typedef odp_time_t env_time_t;
+
+/* Zero time stamp */
+#define ENV_TIME_NULL ODP_TIME_NULL
+
+/**
+ * Returns current local time stamp value.
+ * Local time is thread specific and must not be shared between threads.
+ *
+ * @return Local time stamp
+ */
+static inline env_time_t env_time_local(void)
+{
+	return odp_time_local();
+}
+
+/**
+ * Returns current global time stamp value.
+ * Global time can be shared between threads.
+ *
+ * @return Global time stamp
+ */
+static inline env_time_t env_time_global(void)
+{
+	return odp_time_global();
+}
+
+/**
+ * Returns difference of time stamps (time2 - time1).
+ *
+ * @param time2    Second time stamp
+ * @param time1    First time stamp
+ *
+ * @return Difference between given time stamps
+ */
+static inline env_time_t env_time_diff(env_time_t time2, env_time_t time1)
+{
+	return odp_time_diff(time2, time1);
+}
+
+/**
+ * Returns difference of time stamps (time2 - time1) in nanoseconds.
+ *
+ * @param time2    Second time stamp
+ * @param time1    First time stamp
+ *
+ * @return Difference between given time stamps in nanoseconds
+ */
+static inline uint64_t env_time_diff_ns(env_time_t time2, env_time_t time1)
+{
+	return odp_time_diff_ns(time2, time1);
+}
+
+/**
+ * Sum of time stamps
+ *
+ * @param time1    First time stamp
+ * @param time2    Second time stamp
+ *
+ * @return Sum of given time stamps
+ */
+static inline env_time_t env_time_sum(env_time_t time1, env_time_t time2)
+{
+	return odp_time_sum(time1, time2);
+}
+
+/**
+ * Convert nanoseconds to local time.
+ *
+ * @param ns    Time in nanoseconds
+ *
+ * @return Local time stamp
+ */
+static inline env_time_t env_time_local_from_ns(uint64_t ns)
+{
+	return odp_time_local_from_ns(ns);
+}
+
+/**
+ * Convert nanoseconds to global time
+ *
+ * @param ns    Time in nanoseconds
+ *
+ * @return Global time stamp
+ */
+static inline env_time_t env_time_global_from_ns(uint64_t ns)
+{
+	return odp_time_global_from_ns(ns);
+}
+
+/**
+ * Compare time stamps.
+ *
+ * @param time2    Second time stamp
+ * @param time1    First time stamp
+ *
+ * @retval <0 when time2 < time1
+ * @retval  0 when time2 == time1
+ * @retval >0 when time2 > time1
+ */
+static inline int env_time_cmp(env_time_t time2, env_time_t time1)
+{
+	return odp_time_cmp(time2, time1);
+}
+
+ /**
+  * Convert time stamp to nanoseconds
+  *
+  * @param time    Time stamp
+  *
+  * @return time in nanoseconds
+  */
+static inline uint64_t env_time_to_ns(env_time_t time)
+{
+	return odp_time_to_ns(time);
+}
+
+/**
+ * Convert time stamp to cpu cycles
+ *
+ * @param time    Time stamp
+ * @param hz      CPU Hz
+ *
+ * @return cpu cycles
+ */
+#ifdef __SIZEOF_INT128__
+
+static inline uint64_t env_time_to_cycles(env_time_t time, uint64_t hz)
+{
+	__uint128_t cycles;
+
+	cycles = (__uint128_t)odp_time_to_ns(time) * hz / 1000000000;
+	return (uint64_t)cycles;
+}
+#else
+static inline uint64_t env_time_to_cycles(env_time_t time, uint64_t hz)
+{
+	return odp_time_to_ns(time) * (hz / 1000000) / 1000;
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ENV_TIME_H_ */

--- a/include/event_machine/platform/env/environment.h
+++ b/include/event_machine/platform/env/environment.h
@@ -42,6 +42,8 @@
 extern "C" {
 #endif
 
+#include <stdlib.h>
+
 #include <odp_api.h>
 /* env generic macros */
 #include <event_machine/platform/env/env_macros.h>
@@ -87,6 +89,7 @@ extern "C" {
 #include <event_machine/platform/env/env_barrier.h>
 #include <event_machine/platform/env/env_sharedmem.h>
 #include <event_machine/platform/env/env_spinlock.h>
+#include <event_machine/platform/env/env_time.h>
 
 /**
  * Panic

--- a/include/event_machine/platform/event_machine_config.h
+++ b/include/event_machine/platform/event_machine_config.h
@@ -172,14 +172,20 @@ extern "C" {
  * Error check level
  *
  * Conditionally compiled error checking level, range 0...3
- * Level 0 gives best performance, but does not do any
- * runtime argument checking (like NULL pointer etc)
+ * Level 0 does not do any runtime argument checking (be careful!)
  * Level 1 adds minimum checks
  * Level 2 adds most checks except the slowest ones
- * Level 3 adds all checks and gives lowest performance (for initial testing
- *         only)
+ * Level 3 adds all checks and gives lowest performance
+ *
+ * @note em-odp: the 'EM_CHECK_LEVEL' value can be overridden by a command-line
+ *               option to the 'configure' script, e.g.:
+ *               $build> ../configure ... --enable-check-level=3
+ *               The overridden value will be made available to the application
+ *               via a pkgconfig set define.
  */
+#ifndef EM_CHECK_LEVEL
 #define EM_CHECK_LEVEL  1
+#endif
 
 /**
  * @def EM_EVENT_GROUP_SAFE_MODE

--- a/include/event_machine/platform/event_machine_hw_types.h
+++ b/include/event_machine/platform/event_machine_hw_types.h
@@ -250,7 +250,43 @@ typedef struct {
 	 * @note Only major types are considered here, setting minor is error
 	 */
 	em_event_type_t event_type;
-	/** Number of subpools within one EM pool, max=EM_MAX_SUBPOOLS */
+	/**
+	 * Alignment offset in bytes for the event payload start address
+	 * (for all events allocated from this EM pool).
+	 *
+	 * The default EM event payload start address alignment is a
+	 * power-of-two that is at minimum 32 bytes (i.e. 32 B, 64 B, 128 B etc.
+	 * depending on e.g. target cache-line size).
+	 * The 'align_offset.value' option can be used to fine-tune the
+	 * start-address by a small offset to e.g. make room for a small
+	 * SW header before the rest of the payload that might need a specific
+	 * alignment for direct HW-access.
+	 * Example: setting 'align_offset.value = 8' makes sure that the payload
+	 * _after_ 8 bytes will be aligned at minimum (2^x) 32 bytes.
+	 *
+	 * This option conserns all events allocated from the pool and overrides
+	 * the global config file option 'pool.align_offset' for this pool.
+	 */
+	struct {
+		/**
+		 * Select: Use pool-specific align-offset 'value' from below or
+		 *         use the global default value from the config file.
+		 * false (0): Use default value from the config file.
+		 * true (not 0): Use pool specific value set below.
+		 */
+		int in_use;
+		/**
+		 * Pool-specific event payload alignment offset value in bytes
+		 * (only evaluated if 'in_use=true').
+		 * Overrides the config file value for this pool.
+		 * The given 'value' must be a small power-of-two: 2, 4, or 8
+		 * 0: Explicitly set 'No align offset' for the pool.
+		 */
+		uint32_t value;
+	} align_offset;
+	/**
+	 * Number of subpools within one EM pool, max=EM_MAX_SUBPOOLS
+	 */
 	int num_subpools;
 	struct {
 		/** Event payload size of the subpool (size > 0)  */
@@ -270,6 +306,8 @@ typedef struct {
 	em_pool_t em_pool;
 	/** Event type of events allocated from the pool */
 	em_event_type_t event_type;
+	/** Event payload alignment offset for events from the pool */
+	uint32_t align_offset;
 	/** Number of subpools within one EM pool, max=EM_MAX_SUBPOOLS */
 	int num_subpools;
 	struct {

--- a/m4/em_libconfig.m4
+++ b/m4/em_libconfig.m4
@@ -1,4 +1,14 @@
-# EM_LIBCONFIG
+##########################################################################
+# Configuration file version
+##########################################################################
+m4_define([_em_config_version_generation], [0])
+m4_define([_em_config_version_major], [0])
+m4_define([_em_config_version_minor], [6])
+
+m4_define([_em_config_version],
+	  [_em_config_version_generation._em_config_version_major._em_config_version_minor])
+
+# EM_LIBCONFIG(CONFIG-FILE-PATH)
 # -----------------------
 AC_DEFUN([EM_LIBCONFIG],
 [dnl
@@ -15,15 +25,29 @@ AC_PROG_SED
 AS_IF([test -z "$OD"], [AC_MSG_ERROR([Could not find 'od'])])
 
 ##########################################################################
+# Check default configuration file
+##########################################################################
+AS_IF([test -z "$1"] || [test ! -f $1],
+      [AC_MSG_ERROR([Default configuration file not found])], [])
+
+conf_ver=_em_config_version
+file_ver=`$SED 's/ //g' $1 | $GREP -oP '(?<=config_file_version=").*?(?=")'`
+
+AS_IF([test "x$conf_ver" = "x$file_ver"], [],
+      [AC_MSG_ERROR([Configuration file version mismatch:
+                     invalid EM config file version:$file_ver from $1,
+		     expected version:$conf_ver)])])
+
+##########################################################################
 # Create a header file em_libconfig_config.h which containins null
 # terminated hex dump of em-odp.conf
 ##########################################################################
 AC_CONFIG_COMMANDS([include/em_libconfig_config.h],
 [mkdir -p include
    (echo "static const char config_builtin[[]] = {"; \
-     $OD -An -v -tx1 < ${srcdir}/config/em-odp.conf | \
+     $OD -An -v -tx1 < $CONFIG_FILE | \
      $SED -e 's/[[0-9a-f]]\+/0x\0,/g' ; \
      echo "0x00 };") > \
    include/em_libconfig_config.h],
- [OD=$OD SED=$SED])
+ [OD=$OD SED=$SED CONFIG_FILE=$1])
 ]) # EM_LIBCONFIG

--- a/m4/em_pthread.m4
+++ b/m4/em_pthread.m4
@@ -1,58 +1,44 @@
+# Copyright (c) 2018, Nokia Solutions and Networks
+# All rights reserved.
 #
-#   Copyright (c) 2018, Nokia Solutions and Networks
-#   All rights reserved.
+# SPDX-License-Identifier:     BSD-3-Clause
 #
-#   Redistribution and use in source and binary forms, with or without
-#   modification, are permitted provided that the following conditions
-#   are met:
-#
-#     * Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#     * Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in the
-#       documentation and/or other materials provided with the distribution.
-#     * Neither the name of the copyright holder nor the names of its
-#       contributors may be used to endorse or promote products derived
-#       from this software without specific prior written permission.
-#
-#   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-#   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-#   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-#   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-#   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-#   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-#   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-#   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-#   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-#   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-#   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
-
+# EM_PTHREAD
+# -----------
+# Check for pthreads availability
 AC_DEFUN([EM_PTHREAD], [
-AC_LANG_PUSH([C])
-em_pthread_status=no
+	AC_LANG_PUSH([C])
+	em_pthread_ok=no
 
-temp_LIBS="$LIBS"
+	em_pthread_save_CC="$CC"
+	em_pthread_save_CFLAGS="$CFLAGS"
+	em_pthread_save_LIBS="$LIBS"
 
-PTHREAD_LIBS="-lpthread"
-LIBS="$PTHREAD_LIBS $LIBS"
+	PTHREAD_LIBS="-lpthread"
+	PTHREAD_CFLAGS="-pthread"
+	AS_IF([test "x$PTHREAD_CC" != "x"], [CC="$PTHREAD_CC"])
+	CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+	LIBS="$PTHREAD_LIBS $LIBS"
 
-AC_TRY_LINK_FUNC([pthread_create], [em_pthread_status=yes])
-AC_MSG_CHECKING([for pthread])
-AC_MSG_RESULT([$em_pthread_status])
+	AC_MSG_CHECKING([for pthread])
+	AC_LINK_IFELSE([AC_LANG_CALL([], [pthread_create])], [em_pthread_ok=yes])
+	AC_MSG_RESULT([$em_pthread_ok])
 
-LIBS="$temp_LIBS"
+	CC="$em_pthread_save_CC"
+	CFLAGS="$em_pthread_save_CFLAGS"
+	LIBS="$em_pthread_save_LIBS"
 
-test -n "$PTHREAD_CC" || PTHREAD_CC="$CC"
+	AS_IF([test "x$em_pthread_ok" != "xno"],
+	      [AC_DEFINE([HAVE_PTHREAD],[1],[POSIX thread libraries are available.])],
+	      [PTHREAD_LIBS=""
+	       PTHREAD_CFLAGS=""
+	       AC_MSG_FAILURE([error, POSIX thread libraries are not found!])
+	      ])
 
-AC_SUBST([PTHREAD_LIBS])
+	test -n "$PTHREAD_CC" || PTHREAD_CC="$CC"
 
-if test "x$em_pthread_status" != "xno"; then
-        AC_DEFINE([HAVE_PTHREAD],[1],[POSIX thread libraries are available.])
-else
-        AC_MSG_RESULT([Error! POSIX thread libraries are not found!])
-        exit -1
-fi
-
-AC_LANG_POP
+	AC_LANG_POP([C])
+	AC_SUBST([PTHREAD_LIBS])
+	AC_SUBST([PTHREAD_CFLAGS])
+	AC_SUBST([PTHREAD_CC])
 ])dnl EM_PTHREAD

--- a/pkgconfig/libemodp.pc.in
+++ b/pkgconfig/libemodp.pc.in
@@ -5,7 +5,7 @@ includedir=@includedir@
 
 Name: libemodp
 Description: EM-ODP LIB
-Version: @EMODP_LIBSO_VERSION@
+Version: @EMODP_PKGCONFIG_VERSION@
 Libs: -L${libdir} -lemodp
 Libs.private: @ODP_LIBS@
-Cflags: -I${includedir}
+Cflags: -I${includedir} @EM_CHECK_LEVEL@

--- a/programs/common/cm_pool_config.h
+++ b/programs/common/cm_pool_config.h
@@ -43,22 +43,24 @@ extern "C" {
  */
 #define DEFAULT_POOL_CFG { \
 	.event_type = EM_EVENT_TYPE_SW, \
+	.align_offset = {.in_use = 1, .value = 0},/*override default with 0 */ \
 	.num_subpools = 4, \
 	.subpool[0] = {.size =  256, .num = 16384}, \
 	.subpool[1] = {.size =  512, .num = 1024}, \
 	.subpool[2] = {.size = 1024, .num = 1024}, \
-	.subpool[3] = {.size = 2048, .num = 1024}  \
+	.subpool[3] = {.size = 2048, .num = 1024} \
 }
 
 #define APPL_POOL_1  ((em_pool_t)2)
 #define APPL_POOL_1_NAME "appl_pool_1"
 #define APPL_POOL_1_CFG { \
-	.event_type = EM_EVENT_TYPE_SW, \
+	.event_type = EM_EVENT_TYPE_PACKET, \
+	.align_offset = {.in_use = 0}, /* use default from config file */ \
 	.num_subpools = 4, \
 	.subpool[0] = {.size =  256, .num = 16384}, \
 	.subpool[1] = {.size =  512, .num = 1024}, \
 	.subpool[2] = {.size = 1024, .num = 1024}, \
-	.subpool[3] = {.size = 2048, .num = 1024}  \
+	.subpool[3] = {.size = 2048, .num = 1024} \
 }
 
 /*
@@ -66,6 +68,7 @@ extern "C" {
  * #define APPL_POOL_2_NAME "appl_pool_2"
  * #define APPL_POOL_2_CFG { \
  *	.event_type = EM_EVENT_TYPE_PACKET, \
+ *	.align_offset = {.in_use = 0, .value = 0}, \
  *	.num_subpools = 4, \
  *	.subpool[0] = {.size =  256, .num = 1024}, \
  *	.subpool[1] = {.size =  512, .num = 1024}, \

--- a/programs/example/add-ons/timer_hello.c
+++ b/programs/example/add-ons/timer_hello.c
@@ -236,6 +236,7 @@ void test_start(appl_conf_t *const appl_conf)
 	 */
 	memset(&attr, 0, sizeof(em_timer_attr_t));
 	strncpy(attr.name, "ExampleTimer", EM_TIMER_NAME_LEN);
+	attr.clk_src = EM_TIMER_CLKSRC_DEFAULT;
 	m_shm->tmr = em_timer_create(&attr);
 	test_fatal_if(m_shm->tmr == EM_TIMER_UNDEF, "Failed to create timer!");
 
@@ -344,6 +345,7 @@ static em_status_t app_eo_start(app_eo_ctx_t *eo_ctx, em_eo_t eo,
 	APPL_PRINT("  -resolution: %" PRIu64 " ns\n", attr.resolution);
 	APPL_PRINT("  -max_tmo: %" PRIu64 " ms\n", attr.max_tmo / 1000);
 	APPL_PRINT("  -num_tmo: %d\n", attr.num_tmo);
+	APPL_PRINT("  -clk_src: %d\n", attr.clk_src);
 	APPL_PRINT("  -tick Hz: %" PRIu64 " hz\n",
 		   em_timer_get_freq(m_shm->tmr));
 

--- a/programs/example/dispatcher/dispatcher_callback.c
+++ b/programs/example/dispatcher/dispatcher_callback.c
@@ -190,7 +190,7 @@ void
 test_start(appl_conf_t *const appl_conf)
 {
 	em_eo_t eo_a, eo_b;
-	em_status_t ret;
+	em_status_t ret, eo_start_ret = EM_ERROR;
 
 	/*
 	 * Store the event pool to use, use the EM default pool if no other
@@ -281,10 +281,18 @@ test_start(appl_conf_t *const appl_conf)
 	test_fatal_if(ret != EM_OK, "exit_cb2() unregistering failed!");
 
 	/* Start EO A */
-	em_eo_start_sync(eo_a, NULL, NULL);
+	ret = em_eo_start_sync(eo_a, &eo_start_ret, NULL);
+	test_fatal_if(ret != EM_OK || eo_start_ret != EM_OK,
+		      "em_eo_start(EO A) failed! EO:%" PRI_EO "\n"
+		      "ret:%" PRI_STAT ", EO-start-ret:%" PRI_STAT "",
+		      eo_a, ret, eo_start_ret);
 
 	/* Start EO B */
-	em_eo_start_sync(eo_b, NULL, NULL);
+	ret = em_eo_start_sync(eo_b, &eo_start_ret, NULL);
+	test_fatal_if(ret != EM_OK || eo_start_ret != EM_OK,
+		      "em_eo_start(EO B) failed! EO:%" PRI_EO "\n"
+		      "ret:%" PRI_STAT ", EO-start-ret:%" PRI_STAT "",
+		      eo_b, ret, eo_start_ret);
 }
 
 void

--- a/programs/performance/queues.c
+++ b/programs/performance/queues.c
@@ -152,7 +152,8 @@ typedef struct {
 	int samples;
 	int num_cores;
 	int reset_flag;
-	double mhz;
+	double cpu_mhz;
+	uint64_t cpu_hz;
 	uint64_t print_count;
 	env_atomic64_t ready_count;
 	/*  if using CONST_NUM_EVENTS:*/
@@ -165,15 +166,15 @@ typedef struct {
  */
 typedef struct {
 	uint64_t events;
-	uint64_t begin_cycles;
-	uint64_t end_cycles;
-	uint64_t diff_cycles;
+	env_time_t begin_time;
+	env_time_t end_time;
+	env_time_t diff_time;
 	struct {
 		uint64_t events;
-		uint64_t hi_prio_ave;
-		uint64_t hi_prio_max;
-		uint64_t lo_prio_ave;
-		uint64_t lo_prio_max;
+		env_time_t hi_prio_ave;
+		env_time_t hi_prio_max;
+		env_time_t lo_prio_ave;
+		env_time_t lo_prio_max;
 	} latency;
 	/* Pad size to a multiple of cache line size */
 	void *end[0] ENV_CACHE_LINE_ALIGNED;
@@ -218,7 +219,7 @@ COMPILE_TIME_ASSERT(sizeof(queue_context_t) % ENV_CACHE_LINE_SIZE == 0,
  */
 typedef struct {
 	/* Send time stamp */
-	uint64_t send_time;
+	env_time_t send_time;
 	/* Sequence number */
 	int seq;
 	/* Test data */
@@ -283,7 +284,7 @@ alloc_free_per_event(em_event_t event);
 
 static inline void
 measure_latency(perf_event_t *const perf_event, queue_context_t *const q_ctx,
-		uint64_t recv_time);
+		env_time_t recv_time);
 
 /**
  * Main function
@@ -366,7 +367,6 @@ test_start(appl_conf_t *const appl_conf)
 {
 	eo_context_t *eo_ctx;
 	em_status_t ret, start_ret = EM_ERROR;
-	uint32_t hz;
 	const int q_ctx_size = sizeof(perf_shm->queue_context_tbl);
 	int i;
 
@@ -397,8 +397,9 @@ test_start(appl_conf_t *const appl_conf)
 	test_fatal_if(perf_shm->pool == EM_POOL_UNDEF,
 		      "Undefined application event pool!");
 
-	hz = env_core_hz();
-	perf_shm->test_status.mhz = ((double)hz) / 1000000.0;
+	perf_shm->test_status.cpu_hz = env_core_hz();
+	perf_shm->test_status.cpu_mhz = (double)perf_shm->test_status.cpu_hz /
+					 1000000.0;
 	perf_shm->test_status.reset_flag = 0;
 	perf_shm->test_status.num_cores = em_core_count();
 	perf_shm->test_status.free_flag = 0;
@@ -502,7 +503,7 @@ queue_step(void)
 				      "EM alloc failed (%i)", i);
 			perf_event = em_event_pointer(event);
 			perf_event->seq = i;
-			perf_event->send_time = env_get_cycle();
+			perf_event->send_time = env_time_global();
 
 			/* Allocate events evenly to the queues */
 			q_ctx = &perf_shm->queue_context_tbl[i % queue_count];
@@ -525,7 +526,7 @@ queue_step(void)
 
 				perf_event = em_event_pointer(event);
 				perf_event->seq = i * NUM_EVENTS + j;
-				perf_event->send_time = env_get_cycle();
+				perf_event->send_time = env_time_global();
 
 				ret = em_send(event, q_ctx->this_queue);
 				test_fatal_if(ret != EM_OK,
@@ -601,7 +602,7 @@ static void
 receive_func(void *eo_context, em_event_t event, em_event_type_t type,
 	     em_queue_t queue, void *q_context)
 {
-	uint64_t recv_time;
+	env_time_t recv_time;
 	perf_event_t *perf_event;
 
 	if (unlikely(appl_shm->exit_flag)) {
@@ -610,7 +611,7 @@ receive_func(void *eo_context, em_event_t event, em_event_type_t type,
 	}
 
 	if (MEASURE_LATENCY) {
-		recv_time = env_get_cycle();
+		recv_time = env_time_global();
 		perf_event = em_event_pointer(event);
 	}
 
@@ -640,7 +641,7 @@ receive_func(void *eo_context, em_event_t event, em_event_type_t type,
 
 	if (MEASURE_LATENCY) {
 		measure_latency(perf_event, q_ctx, recv_time);
-		perf_event->send_time = env_get_cycle();
+		perf_event->send_time = env_time_global();
 	}
 	/* Send the event to the next queue */
 	ret = em_send(event, dst_queue);
@@ -697,7 +698,7 @@ update_test_state(em_event_t event)
 
 		if (unlikely(core_state != CORE_STATE_IDLE)) {
 			core_state = CORE_STATE_IDLE;
-			cstat->begin_cycles = 0;
+			cstat->begin_time = ENV_TIME_NULL;
 
 			ready_count =
 			env_atomic64_add_return(&tstat->ready_count, 1);
@@ -719,12 +720,12 @@ update_test_state(em_event_t event)
 			}
 		}
 	} else if (unlikely(events == 1)) {
-		cstat->begin_cycles = env_get_cycle();
+		cstat->begin_time = env_time_global();
 		cstat->latency.events = 0;
-		cstat->latency.hi_prio_ave = 0;
-		cstat->latency.hi_prio_max = 0;
-		cstat->latency.lo_prio_ave = 0;
-		cstat->latency.lo_prio_max = 0;
+		cstat->latency.hi_prio_ave = ENV_TIME_NULL;
+		cstat->latency.hi_prio_max = ENV_TIME_NULL;
+		cstat->latency.lo_prio_ave = ENV_TIME_NULL;
+		cstat->latency.lo_prio_max = ENV_TIME_NULL;
 
 		core_state = CORE_STATE_MEASURE;
 	} else if (unlikely(events == EVENTS_PER_SAMPLE)) {
@@ -732,18 +733,13 @@ update_test_state(em_event_t event)
 		 * Measurements done for this step. Store results and continue
 		 * receiving events until all cores are done.
 		 */
-		uint64_t diff, begin_cycles, end_cycles;
+		env_time_t begin_time, end_time;
 
-		cstat->end_cycles = env_get_cycle();
+		cstat->end_time = env_time_global();
 
-		end_cycles = cstat->end_cycles;
-		begin_cycles = cstat->begin_cycles;
-		if (likely(end_cycles > begin_cycles))
-			diff = end_cycles - begin_cycles;
-		else
-			diff = UINT64_MAX - begin_cycles + end_cycles + 1;
-
-		cstat->diff_cycles = diff;
+		end_time = cstat->end_time;
+		begin_time = cstat->begin_time;
+		cstat->diff_time = env_time_diff(end_time, begin_time);
 
 		ready_count = env_atomic64_add_return(&tstat->ready_count, 1);
 
@@ -878,50 +874,81 @@ static void
 print_test_statistics(test_status_t *test_status, int print_header,
 		      core_stat_t core_stat[])
 {
-	uint64_t total_cycles = 0;
-	uint64_t total_events = test_status->num_cores * EVENTS_PER_SAMPLE;
-	uint64_t latency_events = 0;
-	uint64_t latency_hi_ave = 0;
-	uint64_t latency_hi_max = 0;
-	uint64_t latency_lo_ave = 0;
-	uint64_t latency_lo_max = 0;
-	double latency_per_hi_ave;
-	double latency_per_lo_ave;
-	double cycles_per_event, events_per_sec;
-	int i;
+	const int num_cores = test_status->num_cores;
+	const uint64_t cpu_hz = test_status->cpu_hz;
+	const double cpu_mhz = test_status->cpu_mhz;
+	const uint64_t total_events = (uint64_t)num_cores * EVENTS_PER_SAMPLE;
+	const uint64_t print_count = test_status->print_count++;
+	env_time_t total_time = ENV_TIME_NULL;
 
-	for (i = 0; i < test_status->num_cores; i++) {
-		total_cycles += core_stat[i].diff_cycles;
-		latency_events += core_stat[i].latency.events;
-		latency_hi_ave += core_stat[i].latency.hi_prio_ave;
-		latency_lo_ave += core_stat[i].latency.lo_prio_ave;
-		if (core_stat[i].latency.hi_prio_max > latency_hi_max)
-			latency_hi_max = core_stat[i].latency.hi_prio_max;
-		if (core_stat[i].latency.lo_prio_max > latency_lo_max)
-			latency_lo_max = core_stat[i].latency.lo_prio_max;
-	}
+	for (int i = 0; i < num_cores; i++)
+		total_time = env_time_sum(total_time, core_stat[i].diff_time);
 
-	cycles_per_event = (double)total_cycles / (double)total_events;
-	events_per_sec = test_status->mhz * test_status->num_cores /
-			 cycles_per_event; /* Million events/s */
-	latency_per_hi_ave = (double)latency_hi_ave / (double)latency_events;
-	latency_per_lo_ave = (double)latency_lo_ave / (double)latency_events;
+	double cycles_per_event = 0.0;
+	double events_per_sec = 0.0;
 
-	if (MEASURE_LATENCY) {
-		if (print_header)
-			APPL_PRINT(RESULT_PRINTF_LATENCY_HDR);
-		APPL_PRINT(RESULT_PRINTF_LATENCY_FMT,
-			   cycles_per_event, events_per_sec,
-			   latency_per_hi_ave, latency_hi_max,
-			   latency_per_lo_ave, latency_lo_max,
-			   test_status->mhz, test_status->print_count++);
-	} else {
+	if (likely(total_events > 0))
+		cycles_per_event = env_time_to_cycles(total_time, cpu_hz) /
+				   (double)total_events;
+	if (likely(cycles_per_event > 0)) /* Million events/s: */
+		events_per_sec = cpu_mhz * num_cores / cycles_per_event;
+
+	/*
+	 * Print without latency statistics
+	 */
+	if (!MEASURE_LATENCY) {
 		if (print_header)
 			APPL_PRINT(RESULT_PRINTF_HDR);
 		APPL_PRINT(RESULT_PRINTF_FMT,
 			   cycles_per_event, events_per_sec,
-			   test_status->mhz, test_status->print_count++);
+			   cpu_mhz, print_count);
+		return;
 	}
+
+	/*
+	 * Print with latency statistics
+	 */
+	uint64_t latency_events = 0;
+	env_time_t latency_hi_ave = ENV_TIME_NULL;
+	env_time_t latency_hi_max = ENV_TIME_NULL;
+	env_time_t latency_lo_ave = ENV_TIME_NULL;
+	env_time_t latency_lo_max = ENV_TIME_NULL;
+
+	for (int i = 0; i < num_cores; i++) {
+		latency_events += core_stat[i].latency.events;
+		latency_hi_ave = env_time_sum(latency_hi_ave,
+					      core_stat[i].latency.hi_prio_ave);
+		latency_lo_ave = env_time_sum(latency_lo_ave,
+					      core_stat[i].latency.lo_prio_ave);
+
+		if (env_time_cmp(core_stat[i].latency.hi_prio_max,
+				 latency_hi_max) > 0) {
+			latency_hi_max = core_stat[i].latency.hi_prio_max;
+		}
+		if (env_time_cmp(core_stat[i].latency.lo_prio_max,
+				 latency_lo_max) > 0) {
+			latency_lo_max = core_stat[i].latency.lo_prio_max;
+		}
+	}
+
+	double lat_per_hi_ave = 0.0;
+	double lat_per_lo_ave = 0.0;
+
+	if (likely(latency_events > 0)) {
+		lat_per_hi_ave = env_time_to_cycles(latency_hi_ave, cpu_hz) /
+				 (double)latency_events;
+		lat_per_lo_ave = env_time_to_cycles(latency_lo_ave, cpu_hz) /
+				 (double)latency_events;
+	}
+
+	if (print_header)
+		APPL_PRINT(RESULT_PRINTF_LATENCY_HDR);
+	APPL_PRINT(RESULT_PRINTF_LATENCY_FMT,
+		   cycles_per_event, events_per_sec, lat_per_hi_ave,
+		   env_time_to_cycles(latency_hi_max, cpu_hz),
+		   lat_per_lo_ave,
+		   env_time_to_cycles(latency_lo_max, cpu_hz),
+		   cpu_mhz, print_count);
 }
 
 /**
@@ -931,7 +958,7 @@ static inline em_event_t
 alloc_free_per_event(em_event_t event)
 {
 	perf_event_t *perf_event = em_event_pointer(event);
-	uint64_t send_time = perf_event->send_time;
+	env_time_t send_time = perf_event->send_time;
 	int seq = perf_event->seq;
 	size_t event_size = em_event_get_size(event);
 
@@ -952,12 +979,12 @@ alloc_free_per_event(em_event_t event)
  */
 static inline void
 measure_latency(perf_event_t *const perf_event, queue_context_t *const q_ctx,
-		uint64_t recv_time)
+		env_time_t recv_time)
 {
 	const int core = em_core_id();
 	core_stat_t *const cstat = &perf_shm->core_stat[core];
-	const uint64_t send_time = perf_event->send_time;
-	uint64_t latency;
+	const env_time_t send_time = perf_event->send_time;
+	env_time_t latency;
 
 	if (perf_shm->test_status.reset_flag ||
 	    cstat->events == 0 || cstat->events >= EVENTS_PER_SAMPLE)
@@ -965,18 +992,17 @@ measure_latency(perf_event_t *const perf_event, queue_context_t *const q_ctx,
 
 	cstat->latency.events++;
 
-	if (likely(recv_time > send_time))
-		latency = recv_time - send_time;
-	else
-		latency = UINT64_MAX - send_time + recv_time + 1;
+	latency = env_time_diff(recv_time, send_time);
 
 	if (q_ctx->prio == EM_QUEUE_PRIO_HIGH) {
-		cstat->latency.hi_prio_ave += latency;
-		if (latency > cstat->latency.hi_prio_max)
+		cstat->latency.hi_prio_ave =
+		env_time_sum(cstat->latency.hi_prio_ave, latency);
+		if (env_time_cmp(latency, cstat->latency.hi_prio_max) > 0)
 			cstat->latency.hi_prio_max = latency;
 	} else {
-		cstat->latency.lo_prio_ave += latency;
-		if (latency > cstat->latency.lo_prio_max)
+		cstat->latency.lo_prio_ave =
+		env_time_sum(cstat->latency.lo_prio_ave, latency);
+		if (env_time_cmp(latency, cstat->latency.lo_prio_max) > 0)
 			cstat->latency.lo_prio_max = latency;
 	}
 }

--- a/programs/performance/queues_unscheduled.c
+++ b/programs/performance/queues_unscheduled.c
@@ -163,7 +163,8 @@ typedef struct {
 	int samples;
 	int num_cores;
 	int reset_flag;
-	double mhz;
+	double cpu_mhz;
+	uint64_t cpu_hz;
 	uint64_t print_count;
 	env_atomic64_t ready_count;
 	/*  if using CONST_NUM_EVENTS:*/
@@ -176,15 +177,15 @@ typedef struct {
  */
 typedef struct {
 	uint64_t events;
-	uint64_t begin_cycles;
-	uint64_t end_cycles;
-	uint64_t diff_cycles;
+	env_time_t begin_time;
+	env_time_t end_time;
+	env_time_t diff_time;
 	struct {
 		uint64_t events;
-		uint64_t hi_prio_ave;
-		uint64_t hi_prio_max;
-		uint64_t lo_prio_ave;
-		uint64_t lo_prio_max;
+		env_time_t hi_prio_ave;
+		env_time_t hi_prio_max;
+		env_time_t lo_prio_ave;
+		env_time_t lo_prio_max;
 	} latency;
 	/* Pad size to a multiple of cache line size */
 	void *end[0] ENV_CACHE_LINE_ALIGNED;
@@ -240,7 +241,7 @@ COMPILE_TIME_ASSERT(sizeof(queue_context_t) % ENV_CACHE_LINE_SIZE == 0,
  */
 typedef struct {
 	/* Send time stamp */
-	uint64_t send_time;
+	env_time_t send_time;
 	/* Sequence number */
 	int seq;
 	/* Test data */
@@ -305,7 +306,7 @@ alloc_free_per_event(em_event_t event);
 
 static inline void
 measure_latency(perf_event_t *const perf_event, queue_context_t *const q_ctx,
-		uint64_t recv_time);
+		env_time_t recv_time);
 
 /**
  * Main function
@@ -388,7 +389,6 @@ test_start(appl_conf_t *const appl_conf)
 {
 	eo_context_t *eo_ctx;
 	em_status_t ret, start_ret = EM_ERROR;
-	uint32_t hz;
 	const int q_ctx_size = sizeof(perf_shm->queue_context_tbl);
 	int i;
 
@@ -419,8 +419,9 @@ test_start(appl_conf_t *const appl_conf)
 	test_fatal_if(perf_shm->pool == EM_POOL_UNDEF,
 		      "Undefined application event pool!");
 
-	hz = env_core_hz();
-	perf_shm->test_status.mhz = ((double)hz) / 1000000.0;
+	perf_shm->test_status.cpu_hz = env_core_hz();
+	perf_shm->test_status.cpu_mhz = (double)perf_shm->test_status.cpu_hz /
+					 1000000.0;
 	perf_shm->test_status.reset_flag = 0;
 	perf_shm->test_status.num_cores = em_core_count();
 	perf_shm->test_status.free_flag = 0;
@@ -500,7 +501,10 @@ test_stop(appl_conf_t *const appl_conf)
 				break;
 			em_free(unsch_event);
 		}
-		em_queue_delete(unsch_queue);
+		ret = em_queue_delete(unsch_queue);
+		test_fatal_if(ret != EM_OK,
+			      "Unsch-Queue:%" PRI_QUEUE " delete:%" PRI_STAT "",
+			      unsch_queue, ret);
 	}
 }
 
@@ -563,7 +567,7 @@ queue_step(void)
 
 			perf_event = em_event_pointer(event);
 			perf_event->seq = i;
-			perf_event->send_time = env_get_cycle();
+			perf_event->send_time = env_time_global();
 
 			/* Allocate events evenly to the queues */
 			q_ctx = &perf_shm->queue_context_tbl[i % queue_count];
@@ -612,7 +616,7 @@ queue_step(void)
 
 				perf_event = em_event_pointer(events[j]);
 				perf_event->seq = i * NUM_EVENTS + j;
-				perf_event->send_time = env_get_cycle();
+				perf_event->send_time = env_time_global();
 			}
 			num = em_send_multi(events, NUM_EVENTS,
 					    q_ctx->sch_q.this_queue);
@@ -690,11 +694,11 @@ static void
 receive_func(void *eo_context, em_event_t event, em_event_type_t type,
 	     em_queue_t queue, void *q_context)
 {
-	uint64_t recv_time;
+	env_time_t recv_time;
 	perf_event_t *perf_event;
 
 	if (MEASURE_LATENCY) {
-		recv_time = env_get_cycle();
+		recv_time = env_time_global();
 		perf_event = em_event_pointer(event);
 	}
 
@@ -755,7 +759,7 @@ receive_func(void *eo_context, em_event_t event, em_event_type_t type,
 
 	/* Send the scheduled event to the next scheduled queue */
 	if (MEASURE_LATENCY)
-		perf_event->send_time = env_get_cycle();
+		perf_event->send_time = env_time_global();
 	ret = em_send(event, dst_queue);
 	if (unlikely(ret != EM_OK)) {
 		em_free(event);
@@ -812,7 +816,7 @@ update_test_state(em_event_t event, em_event_t unsch_event)
 
 		if (unlikely(core_state != CORE_STATE_IDLE)) {
 			core_state = CORE_STATE_IDLE;
-			cstat->begin_cycles = 0;
+			cstat->begin_time = ENV_TIME_NULL;
 
 			ready_count =
 			env_atomic64_add_return(&tstat->ready_count, 1);
@@ -834,12 +838,12 @@ update_test_state(em_event_t event, em_event_t unsch_event)
 			}
 		}
 	} else if (unlikely(events == 2)) {
-		cstat->begin_cycles = env_get_cycle();
+		cstat->begin_time = env_time_global();
 		cstat->latency.events = 0;
-		cstat->latency.hi_prio_ave = 0;
-		cstat->latency.hi_prio_max = 0;
-		cstat->latency.lo_prio_ave = 0;
-		cstat->latency.lo_prio_max = 0;
+		cstat->latency.hi_prio_ave = ENV_TIME_NULL;
+		cstat->latency.hi_prio_max = ENV_TIME_NULL;
+		cstat->latency.lo_prio_ave = ENV_TIME_NULL;
+		cstat->latency.lo_prio_max = ENV_TIME_NULL;
 
 		core_state = CORE_STATE_MEASURE;
 	} else if (unlikely(events == EVENTS_PER_SAMPLE)) {
@@ -847,18 +851,13 @@ update_test_state(em_event_t event, em_event_t unsch_event)
 		 * Measurements done for this step. Store results and continue
 		 * receiving events until all cores are done.
 		 */
-		uint64_t diff, begin_cycles, end_cycles;
+		env_time_t begin_time, end_time;
 
-		cstat->end_cycles = env_get_cycle();
+		cstat->end_time = env_time_global();
 
-		end_cycles = cstat->end_cycles;
-		begin_cycles = cstat->begin_cycles;
-		if (likely(end_cycles > begin_cycles))
-			diff = end_cycles - begin_cycles;
-		else
-			diff = UINT64_MAX - begin_cycles + end_cycles + 1;
-
-		cstat->diff_cycles = diff;
+		end_time = cstat->end_time;
+		begin_time = cstat->begin_time;
+		cstat->diff_time = env_time_diff(end_time, begin_time);
 
 		ready_count = env_atomic64_add_return(&tstat->ready_count, 1);
 
@@ -1041,50 +1040,82 @@ static void
 print_test_statistics(test_status_t *test_status, int print_header,
 		      core_stat_t core_stat[])
 {
-	uint64_t total_cycles = 0;
-	uint64_t total_events = test_status->num_cores * EVENTS_PER_SAMPLE;
-	uint64_t latency_events = 0;
-	uint64_t latency_hi_ave = 0;
-	uint64_t latency_hi_max = 0;
-	uint64_t latency_lo_ave = 0;
-	uint64_t latency_lo_max = 0;
-	double latency_per_hi_ave;
-	double latency_per_lo_ave;
-	double cycles_per_event, events_per_sec;
-	int i;
+	const int num_cores = test_status->num_cores;
+	const uint64_t cpu_hz = test_status->cpu_hz;
+	const double cpu_mhz = test_status->cpu_mhz;
+	const uint64_t total_events = (uint64_t)num_cores * EVENTS_PER_SAMPLE;
+	const uint64_t print_count = test_status->print_count++;
+	env_time_t total_time = ENV_TIME_NULL;
 
-	for (i = 0; i < test_status->num_cores; i++) {
-		total_cycles += core_stat[i].diff_cycles;
-		latency_events += core_stat[i].latency.events;
-		latency_hi_ave += core_stat[i].latency.hi_prio_ave;
-		latency_lo_ave += core_stat[i].latency.lo_prio_ave;
-		if (core_stat[i].latency.hi_prio_max > latency_hi_max)
-			latency_hi_max = core_stat[i].latency.hi_prio_max;
-		if (core_stat[i].latency.lo_prio_max > latency_lo_max)
-			latency_lo_max = core_stat[i].latency.lo_prio_max;
-	}
+	for (int i = 0; i < num_cores; i++)
+		total_time = env_time_sum(total_time, core_stat[i].diff_time);
 
-	cycles_per_event = (double)total_cycles / (double)total_events;
-	events_per_sec = test_status->mhz * test_status->num_cores /
-			 cycles_per_event; /* Million events/s */
-	latency_per_hi_ave = (double)latency_hi_ave / (double)latency_events;
-	latency_per_lo_ave = (double)latency_lo_ave / (double)latency_events;
+	double cycles_per_event = 0.0;
+	double events_per_sec = 0.0;
 
-	if (MEASURE_LATENCY) {
-		if (print_header)
-			APPL_PRINT(RESULT_PRINTF_LATENCY_HDR);
-		APPL_PRINT(RESULT_PRINTF_LATENCY_FMT,
-			   cycles_per_event, events_per_sec,
-			   latency_per_hi_ave, latency_hi_max,
-			   latency_per_lo_ave, latency_lo_max,
-			   test_status->mhz, test_status->print_count++);
-	} else {
+	if (likely(total_events > 0))
+		cycles_per_event = env_time_to_cycles(total_time, cpu_hz) /
+				   (double)total_events;
+	if (likely(cycles_per_event > 0)) /* Million events/s: */
+		events_per_sec = cpu_mhz * num_cores / cycles_per_event;
+
+	/*
+	 * Print without latency statistics
+	 */
+	if (!MEASURE_LATENCY) {
 		if (print_header)
 			APPL_PRINT(RESULT_PRINTF_HDR);
 		APPL_PRINT(RESULT_PRINTF_FMT,
 			   cycles_per_event, events_per_sec,
-			   test_status->mhz, test_status->print_count++);
+			   cpu_mhz, print_count);
+		return;
 	}
+
+	/*
+	 * Print with latency statistics
+	 */
+	uint64_t latency_events = 0;
+	env_time_t latency_hi_ave = ENV_TIME_NULL;
+	env_time_t latency_hi_max = ENV_TIME_NULL;
+	env_time_t latency_lo_ave = ENV_TIME_NULL;
+	env_time_t latency_lo_max = ENV_TIME_NULL;
+
+	for (int i = 0; i < num_cores; i++) {
+		latency_events += core_stat[i].latency.events;
+
+		latency_hi_ave = env_time_sum(latency_hi_ave,
+					      core_stat[i].latency.hi_prio_ave);
+		latency_lo_ave = env_time_sum(latency_lo_ave,
+					      core_stat[i].latency.lo_prio_ave);
+
+		if (env_time_cmp(core_stat[i].latency.hi_prio_max,
+				 latency_hi_max) > 0) {
+			latency_hi_max = core_stat[i].latency.hi_prio_max;
+		}
+		if (env_time_cmp(core_stat[i].latency.lo_prio_max,
+				 latency_lo_max) > 0) {
+			latency_lo_max = core_stat[i].latency.lo_prio_max;
+		}
+	}
+
+	double lat_per_hi_ave = 0.0;
+	double lat_per_lo_ave = 0.0;
+
+	if (likely(latency_events > 0)) {
+		lat_per_hi_ave = env_time_to_cycles(latency_hi_ave, cpu_hz) /
+				 (double)latency_events;
+		lat_per_lo_ave = env_time_to_cycles(latency_lo_ave, cpu_hz) /
+				 (double)latency_events;
+	}
+
+	if (print_header)
+		APPL_PRINT(RESULT_PRINTF_LATENCY_HDR);
+	APPL_PRINT(RESULT_PRINTF_LATENCY_FMT,
+		   cycles_per_event, events_per_sec, lat_per_hi_ave,
+		   env_time_to_cycles(latency_hi_max, cpu_hz),
+		   lat_per_lo_ave,
+		   env_time_to_cycles(latency_lo_max, cpu_hz),
+		   cpu_mhz, print_count);
 }
 
 /**
@@ -1094,7 +1125,7 @@ static inline em_event_t
 alloc_free_per_event(em_event_t event)
 {
 	perf_event_t *perf_event = em_event_pointer(event);
-	uint64_t send_time = perf_event->send_time;
+	env_time_t send_time = perf_event->send_time;
 	int seq = perf_event->seq;
 	size_t event_size = em_event_get_size(event);
 
@@ -1115,12 +1146,12 @@ alloc_free_per_event(em_event_t event)
  */
 static inline void
 measure_latency(perf_event_t *const perf_event, queue_context_t *const q_ctx,
-		uint64_t recv_time)
+		env_time_t recv_time)
 {
 	const int core = em_core_id();
 	core_stat_t *const cstat = &perf_shm->core_stat[core];
-	const uint64_t send_time = perf_event->send_time;
-	uint64_t latency;
+	const env_time_t send_time = perf_event->send_time;
+	env_time_t latency;
 
 	if (perf_shm->test_status.reset_flag ||
 	    cstat->events == 0 || cstat->events >= EVENTS_PER_SAMPLE)
@@ -1128,18 +1159,17 @@ measure_latency(perf_event_t *const perf_event, queue_context_t *const q_ctx,
 
 	cstat->latency.events++;
 
-	if (likely(recv_time > send_time))
-		latency = recv_time - send_time;
-	else
-		latency = UINT64_MAX - send_time + recv_time + 1;
+	latency = env_time_diff(recv_time, send_time);
 
 	if (q_ctx->sch_q.prio == EM_QUEUE_PRIO_HIGH) {
-		cstat->latency.hi_prio_ave += latency;
-		if (latency > cstat->latency.hi_prio_max)
+		cstat->latency.hi_prio_ave =
+		env_time_sum(cstat->latency.hi_prio_ave, latency);
+		if (env_time_cmp(latency, cstat->latency.hi_prio_max) > 0)
 			cstat->latency.hi_prio_max = latency;
 	} else {
-		cstat->latency.lo_prio_ave += latency;
-		if (latency > cstat->latency.lo_prio_max)
+		cstat->latency.lo_prio_ave =
+		env_time_sum(cstat->latency.lo_prio_ave, latency);
+		if (env_time_cmp(latency, cstat->latency.lo_prio_max) > 0)
 			cstat->latency.lo_prio_max = latency;
 	}
 }

--- a/programs/performance/send_multi.c
+++ b/programs/performance/send_multi.c
@@ -171,7 +171,8 @@ typedef struct {
 	int samples;
 	int num_cores;
 	int reset_flag;
-	double mhz;
+	double cpu_mhz;
+	uint64_t cpu_hz;
 	uint64_t print_count;
 	env_atomic64_t ready_count;
 	/*  if using CONST_NUM_EVENTS:*/
@@ -184,15 +185,15 @@ typedef struct {
  */
 typedef struct {
 	uint64_t events;
-	uint64_t begin_cycles;
-	uint64_t end_cycles;
-	uint64_t diff_cycles;
+	env_time_t begin_time;
+	env_time_t end_time;
+	env_time_t diff_time;
 	struct {
 		uint64_t events;
-		uint64_t hi_prio_ave;
-		uint64_t hi_prio_max;
-		uint64_t lo_prio_ave;
-		uint64_t lo_prio_max;
+		env_time_t hi_prio_ave;
+		env_time_t hi_prio_max;
+		env_time_t lo_prio_ave;
+		env_time_t lo_prio_max;
 	} latency;
 	/* Pad size to a multiple of cache line size */
 	void *end[0] ENV_CACHE_LINE_ALIGNED;
@@ -252,7 +253,7 @@ COMPILE_TIME_ASSERT(sizeof(queue_context_t) % ENV_CACHE_LINE_SIZE == 0,
  */
 typedef struct {
 	/* Send time stamp */
-	uint64_t send_time;
+	env_time_t send_time;
 	/* Sequence number */
 	int seq;
 	/* Test data */
@@ -317,7 +318,7 @@ alloc_free_per_event(em_event_t event);
 
 static inline void
 measure_latency(perf_event_t *const perf_event, queue_context_t *const q_ctx,
-		uint64_t recv_time);
+		env_time_t recv_time);
 
 /**
  * Main function
@@ -400,7 +401,6 @@ test_start(appl_conf_t *const appl_conf)
 {
 	eo_context_t *eo_ctx;
 	em_status_t ret, start_ret = EM_ERROR;
-	uint32_t hz;
 	const int q_ctx_size = sizeof(perf_shm->queue_context_tbl);
 	int i;
 
@@ -431,8 +431,9 @@ test_start(appl_conf_t *const appl_conf)
 	test_fatal_if(perf_shm->pool == EM_POOL_UNDEF,
 		      "Undefined application event pool!");
 
-	hz = env_core_hz();
-	perf_shm->test_status.mhz = ((double)hz) / 1000000.0;
+	perf_shm->test_status.cpu_hz = env_core_hz();
+	perf_shm->test_status.cpu_mhz = (double)perf_shm->test_status.cpu_hz /
+					 1000000.0;
 	perf_shm->test_status.reset_flag = 0;
 	perf_shm->test_status.num_cores = em_core_count();
 	perf_shm->test_status.free_flag = 0;
@@ -513,7 +514,10 @@ test_stop(appl_conf_t *const appl_conf)
 				break;
 			em_free(unsch_event);
 		}
-		em_queue_delete(unsch_queue);
+		ret = em_queue_delete(unsch_queue);
+		test_fatal_if(ret != EM_OK,
+			      "Unsch-Queue:%" PRI_QUEUE " delete:%" PRI_STAT "",
+			      unsch_queue, ret);
 	}
 	/* Delete the unscheduled 'storage' queues */
 	for (i = 0; i < NUM_QUEUES; i++) {
@@ -530,7 +534,10 @@ test_stop(appl_conf_t *const appl_conf)
 				break;
 			em_free(unsch_event);
 		}
-		em_queue_delete(unsch_queue);
+		ret = em_queue_delete(unsch_queue);
+		test_fatal_if(ret != EM_OK,
+			      "Unsch-Queue:%" PRI_QUEUE " delete:%" PRI_STAT "",
+			      unsch_queue, ret);
 	}
 }
 
@@ -593,7 +600,7 @@ queue_step(void)
 
 			perf_event = em_event_pointer(event);
 			perf_event->seq = i;
-			perf_event->send_time = env_get_cycle();
+			perf_event->send_time = env_time_global();
 
 			/* Allocate events evenly to the queues */
 			q_ctx = &perf_shm->queue_context_tbl[i % queue_count];
@@ -642,7 +649,7 @@ queue_step(void)
 
 				perf_event = em_event_pointer(events[j]);
 				perf_event->seq = i * NUM_EVENTS + j;
-				perf_event->send_time = env_get_cycle();
+				perf_event->send_time = env_time_global();
 			}
 			num = em_send_multi(events, NUM_EVENTS,
 					    q_ctx->sch_q.this_queue);
@@ -764,7 +771,7 @@ receive_func(void *eo_context, em_event_t event, em_event_type_t type,
 	em_event_t unsch_events[NUM_STORAGE];
 	perf_event_t *perf_events[NUM_STORAGE];
 	int num, num_unsch;
-	uint64_t recv_time, send_time;
+	env_time_t recv_time, send_time;
 
 	num = em_queue_dequeue_multi(q_ctx->sch_q.storage,
 				     events, NUM_STORAGE - 1);
@@ -788,7 +795,7 @@ receive_func(void *eo_context, em_event_t event, em_event_type_t type,
 	 * calc & print stats, prepare for next step
 	 */
 	if (MEASURE_LATENCY) {
-		recv_time = env_get_cycle();
+		recv_time = env_time_global();
 		for (i = 0; i < num; i++)
 			perf_events[i] = em_event_pointer(events[i]);
 		for (i = 0; i < num; i++)
@@ -828,7 +835,7 @@ receive_func(void *eo_context, em_event_t event, em_event_type_t type,
 			for (i = 0; i < num; i++)
 				perf_events[i] = em_event_pointer(events[i]);
 		}
-		send_time = env_get_cycle();
+		send_time = env_time_global();
 		for (i = 0; i < num; i++)
 			perf_events[i]->send_time = send_time;
 	}
@@ -889,7 +896,7 @@ update_test_state(em_event_t event, em_event_t unsch_event)
 
 		if (unlikely(core_state != CORE_STATE_IDLE)) {
 			core_state = CORE_STATE_IDLE;
-			cstat->begin_cycles = 0;
+			cstat->begin_time = ENV_TIME_NULL;
 
 			ready_count =
 			env_atomic64_add_return(&tstat->ready_count, 1);
@@ -911,12 +918,12 @@ update_test_state(em_event_t event, em_event_t unsch_event)
 			}
 		}
 	} else if (unlikely(events == 2)) {
-		cstat->begin_cycles = env_get_cycle();
+		cstat->begin_time = env_time_global();
 		cstat->latency.events = 0;
-		cstat->latency.hi_prio_ave = 0;
-		cstat->latency.hi_prio_max = 0;
-		cstat->latency.lo_prio_ave = 0;
-		cstat->latency.lo_prio_max = 0;
+		cstat->latency.hi_prio_ave = ENV_TIME_NULL;
+		cstat->latency.hi_prio_max = ENV_TIME_NULL;
+		cstat->latency.lo_prio_ave = ENV_TIME_NULL;
+		cstat->latency.lo_prio_max = ENV_TIME_NULL;
 
 		core_state = CORE_STATE_MEASURE;
 	} else if (unlikely(events == EVENTS_PER_SAMPLE)) {
@@ -924,18 +931,13 @@ update_test_state(em_event_t event, em_event_t unsch_event)
 		 * Measurements done for this step. Store results and continue
 		 * receiving events until all cores are done.
 		 */
-		uint64_t diff, begin_cycles, end_cycles;
+		env_time_t begin_time, end_time;
 
-		cstat->end_cycles = env_get_cycle();
+		cstat->end_time = env_time_global();
 
-		end_cycles = cstat->end_cycles;
-		begin_cycles = cstat->begin_cycles;
-		if (likely(end_cycles > begin_cycles))
-			diff = end_cycles - begin_cycles;
-		else
-			diff = UINT64_MAX - begin_cycles + end_cycles + 1;
-
-		cstat->diff_cycles = diff;
+		end_time = cstat->end_time;
+		begin_time = cstat->begin_time;
+		cstat->diff_time = env_time_diff(end_time, begin_time);
 
 		ready_count = env_atomic64_add_return(&tstat->ready_count, 1);
 
@@ -1136,50 +1138,82 @@ static void
 print_test_statistics(test_status_t *test_status, int print_header,
 		      core_stat_t core_stat[])
 {
-	uint64_t total_cycles = 0;
-	uint64_t total_events = test_status->num_cores * EVENTS_PER_SAMPLE;
-	uint64_t latency_events = 0;
-	uint64_t latency_hi_ave = 0;
-	uint64_t latency_hi_max = 0;
-	uint64_t latency_lo_ave = 0;
-	uint64_t latency_lo_max = 0;
-	double latency_per_hi_ave;
-	double latency_per_lo_ave;
-	double cycles_per_event, events_per_sec;
-	int i;
+	const int num_cores = test_status->num_cores;
+	const uint64_t cpu_hz = test_status->cpu_hz;
+	const double cpu_mhz = test_status->cpu_mhz;
+	const uint64_t total_events = (uint64_t)num_cores * EVENTS_PER_SAMPLE;
+	const uint64_t print_count = test_status->print_count++;
+	env_time_t total_time = ENV_TIME_NULL;
 
-	for (i = 0; i < test_status->num_cores; i++) {
-		total_cycles += core_stat[i].diff_cycles;
-		latency_events += core_stat[i].latency.events;
-		latency_hi_ave += core_stat[i].latency.hi_prio_ave;
-		latency_lo_ave += core_stat[i].latency.lo_prio_ave;
-		if (core_stat[i].latency.hi_prio_max > latency_hi_max)
-			latency_hi_max = core_stat[i].latency.hi_prio_max;
-		if (core_stat[i].latency.lo_prio_max > latency_lo_max)
-			latency_lo_max = core_stat[i].latency.lo_prio_max;
-	}
+	for (int i = 0; i < num_cores; i++)
+		total_time = env_time_sum(total_time, core_stat[i].diff_time);
 
-	cycles_per_event = (double)total_cycles / (double)total_events;
-	events_per_sec = test_status->mhz * test_status->num_cores /
-			 cycles_per_event; /* Million events/s */
-	latency_per_hi_ave = (double)latency_hi_ave / (double)latency_events;
-	latency_per_lo_ave = (double)latency_lo_ave / (double)latency_events;
+	double cycles_per_event = 0.0;
+	double events_per_sec = 0.0;
 
-	if (MEASURE_LATENCY) {
-		if (print_header)
-			APPL_PRINT(RESULT_PRINTF_LATENCY_HDR);
-		APPL_PRINT(RESULT_PRINTF_LATENCY_FMT,
-			   cycles_per_event, events_per_sec,
-			   latency_per_hi_ave, latency_hi_max,
-			   latency_per_lo_ave, latency_lo_max,
-			   test_status->mhz, test_status->print_count++);
-	} else {
+	if (likely(total_events > 0))
+		cycles_per_event = env_time_to_cycles(total_time, cpu_hz) /
+				   (double)total_events;
+	if (likely(cycles_per_event > 0)) /* Million events/s: */
+		events_per_sec = cpu_mhz * num_cores / cycles_per_event;
+
+	/*
+	 * Print without latency statistics
+	 */
+	if (!MEASURE_LATENCY) {
 		if (print_header)
 			APPL_PRINT(RESULT_PRINTF_HDR);
 		APPL_PRINT(RESULT_PRINTF_FMT,
 			   cycles_per_event, events_per_sec,
-			   test_status->mhz, test_status->print_count++);
+			   cpu_mhz, print_count);
+		return;
 	}
+
+	/*
+	 * Print with latency statistics
+	 */
+	uint64_t latency_events = 0;
+	env_time_t latency_hi_ave = ENV_TIME_NULL;
+	env_time_t latency_hi_max = ENV_TIME_NULL;
+	env_time_t latency_lo_ave = ENV_TIME_NULL;
+	env_time_t latency_lo_max = ENV_TIME_NULL;
+
+	for (int i = 0; i < num_cores; i++) {
+		latency_events += core_stat[i].latency.events;
+
+		latency_hi_ave = env_time_sum(latency_hi_ave,
+					      core_stat[i].latency.hi_prio_ave);
+		latency_lo_ave = env_time_sum(latency_lo_ave,
+					      core_stat[i].latency.lo_prio_ave);
+
+		if (env_time_cmp(core_stat[i].latency.hi_prio_max,
+				 latency_hi_max) > 0) {
+			latency_hi_max = core_stat[i].latency.hi_prio_max;
+		}
+		if (env_time_cmp(core_stat[i].latency.lo_prio_max,
+				 latency_lo_max) > 0) {
+			latency_lo_max = core_stat[i].latency.lo_prio_max;
+		}
+	}
+
+	double lat_per_hi_ave = 0.0;
+	double lat_per_lo_ave = 0.0;
+
+	if (likely(latency_events > 0)) {
+		lat_per_hi_ave = env_time_to_cycles(latency_hi_ave, cpu_hz) /
+				 (double)latency_events;
+		lat_per_lo_ave = env_time_to_cycles(latency_lo_ave, cpu_hz) /
+				 (double)latency_events;
+	}
+
+	if (print_header)
+		APPL_PRINT(RESULT_PRINTF_LATENCY_HDR);
+	APPL_PRINT(RESULT_PRINTF_LATENCY_FMT,
+		   cycles_per_event, events_per_sec, lat_per_hi_ave,
+		   env_time_to_cycles(latency_hi_max, cpu_hz),
+		   lat_per_lo_ave,
+		   env_time_to_cycles(latency_lo_max, cpu_hz),
+		   cpu_mhz, print_count);
 }
 
 /**
@@ -1189,7 +1223,7 @@ static inline em_event_t
 alloc_free_per_event(em_event_t event)
 {
 	perf_event_t *perf_event = em_event_pointer(event);
-	uint64_t send_time = perf_event->send_time;
+	env_time_t send_time = perf_event->send_time;
 	int seq = perf_event->seq;
 	size_t event_size = em_event_get_size(event);
 
@@ -1210,12 +1244,12 @@ alloc_free_per_event(em_event_t event)
  */
 static inline void
 measure_latency(perf_event_t *const perf_event, queue_context_t *const q_ctx,
-		uint64_t recv_time)
+		env_time_t recv_time)
 {
 	const int core = em_core_id();
 	core_stat_t *const cstat = &perf_shm->core_stat[core];
-	const uint64_t send_time = perf_event->send_time;
-	uint64_t latency;
+	const env_time_t send_time = perf_event->send_time;
+	env_time_t latency;
 
 	if (perf_shm->test_status.reset_flag ||
 	    cstat->events == 0 || cstat->events >= EVENTS_PER_SAMPLE)
@@ -1223,18 +1257,17 @@ measure_latency(perf_event_t *const perf_event, queue_context_t *const q_ctx,
 
 	cstat->latency.events++;
 
-	if (likely(recv_time > send_time))
-		latency = recv_time - send_time;
-	else
-		latency = UINT64_MAX - send_time + recv_time + 1;
+	latency = env_time_diff(recv_time, send_time);
 
 	if (q_ctx->sch_q.prio == EM_QUEUE_PRIO_HIGH) {
-		cstat->latency.hi_prio_ave += latency;
-		if (latency > cstat->latency.hi_prio_max)
+		cstat->latency.hi_prio_ave =
+		env_time_sum(cstat->latency.hi_prio_ave, latency);
+		if (env_time_cmp(latency, cstat->latency.hi_prio_max) > 0)
 			cstat->latency.hi_prio_max = latency;
 	} else {
-		cstat->latency.lo_prio_ave += latency;
-		if (latency > cstat->latency.lo_prio_max)
+		cstat->latency.lo_prio_ave =
+		env_time_sum(cstat->latency.lo_prio_ave, latency);
+		if (env_time_cmp(latency, cstat->latency.lo_prio_max) > 0)
 			cstat->latency.lo_prio_max = latency;
 	}
 }

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -66,7 +66,8 @@ $(top_srcdir)/include/event_machine/platform/env/env_bitmask.h \
 $(top_srcdir)/include/event_machine/platform/env/env_conf.h \
 $(top_srcdir)/include/event_machine/platform/env/env_macros.h \
 $(top_srcdir)/include/event_machine/platform/env/env_sharedmem.h \
-$(top_srcdir)/include/event_machine/platform/env/env_spinlock.h
+$(top_srcdir)/include/event_machine/platform/env/env_spinlock.h \
+$(top_srcdir)/include/event_machine/platform/env/env_time.h
 
 __LIB__libemodp_la_SOURCES = \
 event_machine_atomic_group.c \

--- a/src/add-ons/event_timer/em_timer.h
+++ b/src/add-ons/event_timer/em_timer.h
@@ -42,20 +42,22 @@
 #define TMR_DBG_PRINT(format, ...) do {} while (0)
 #endif
 
-extern ENV_LOCAL timer_shm_t *timer_shm;
-
-em_status_t timer_init_global(void);
+em_status_t timer_init(timer_storage_t *const tmrs);
 em_status_t timer_init_local(void);
 em_status_t timer_term_local(void);
-em_status_t timer_term_global(void);
+em_status_t timer_term(void);
 
 static inline int
 timer_clksrc_em2odp(em_timer_clksrc_t clksrc_em,
 		    odp_timer_clk_src_t *clksrc_odp /* out */)
 {
 	switch (clksrc_em) {
-	case EM_TIMER_CLKSRC_DEFAULT:
+	case EM_TIMER_CLKSRC_DEFAULT: /* fallthrough */
+	case EM_TIMER_CLKSRC_CPU:
 		*clksrc_odp = ODP_CLOCK_CPU;
+		return 0;
+	case EM_TIMER_CLKSRC_EXT:
+		*clksrc_odp = ODP_CLOCK_EXT;
 		return 0;
 	default:
 		return -1;
@@ -68,7 +70,10 @@ timer_clksrc_odp2em(odp_timer_clk_src_t clksrc_odp,
 {
 	switch (clksrc_odp) {
 	case ODP_CLOCK_CPU:
-		*clksrc_em = EM_TIMER_CLKSRC_DEFAULT;
+		*clksrc_em = EM_TIMER_CLKSRC_CPU;
+		return 0;
+	case ODP_CLOCK_EXT:
+		*clksrc_em = EM_TIMER_CLKSRC_EXT;
 		return 0;
 	default:
 		return -1;

--- a/src/add-ons/event_timer/em_timer_conf.h
+++ b/src/add-ons/event_timer/em_timer_conf.h
@@ -40,8 +40,6 @@
  * Global configuration for the EM timer
  */
 
-/* The name of the EM timer shared memory */
-#define EM_ODP_TIMER_SHM_NAME  "EMTimerShm"
 /* Default timer resolution in ns (if none given by the user) */
 #define EM_ODP_TIMER_RESOL_DEF_NS  1000000
 /* Max number of supported EM timers (= ODP timer pools) */

--- a/src/add-ons/event_timer/em_timer_types.h
+++ b/src/add-ons/event_timer/em_timer_types.h
@@ -42,12 +42,11 @@ typedef struct event_timer_t {
 	int idx;
 } event_timer_t;
 
-/* global shared memory data */
-typedef struct timer_shm_t {
-	odp_shm_t odp_shm ODP_ALIGNED_CACHE;
-	odp_ticketlock_t tlock;
+/* Timer */
+typedef struct {
+	odp_ticketlock_t timer_lock;
 	event_timer_t timer[EM_ODP_MAX_TIMERS];
-} timer_shm_t;
+} timer_storage_t;
 
 /* EM timer handle points to this. Holds the timer state. */
 typedef struct em_timer_timeout_t {

--- a/src/em_core_types.h
+++ b/src/em_core_types.h
@@ -58,7 +58,7 @@ typedef struct {
 
 	struct {
 		/** From ODP thread ids to logical EM core ids */
-		uint8_t logic[EM_MAX_CORES];
+		uint8_t logic[ODP_THREAD_COUNT_MAX];
 		/** From logical EM core ids to ODP thread ids */
 		uint8_t odp_thr[EM_MAX_CORES];
 	} thr_vs_logic;
@@ -73,6 +73,10 @@ typedef struct {
 
 COMPILE_TIME_ASSERT((sizeof(core_map_t) % ENV_CACHE_LINE_SIZE) == 0,
 		    CORE_MAP_T__SIZE_ERROR);
+COMPILE_TIME_ASSERT(EM_MAX_CORES - 1 <= UINT8_MAX,
+		    CORE_MAP_T__TYPE_ERROR1);
+COMPILE_TIME_ASSERT(ODP_THREAD_COUNT_MAX - 1 <= UINT8_MAX,
+		    CORE_MAP_T__TYPE_ERROR2);
 
 /**
  * EM spinlock - Cache line sized & aligned

--- a/src/em_daemon_eo.h
+++ b/src/em_daemon_eo.h
@@ -42,12 +42,6 @@ extern "C" {
 #endif
 
 void
-daemon_eo_shm_init(int first);
-
-void
-daemon_eo_shm_free(void);
-
-void
 daemon_eo_create(void);
 
 void

--- a/src/em_daemon_eo_types.h
+++ b/src/em_daemon_eo_types.h
@@ -1,0 +1,31 @@
+/* Copyright (c) 2020 Nokia Solutions and Networks
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:	BSD-3-Clause
+ */
+
+/**
+ * @file
+ * EM internal daemon eo types & definitions
+ *
+ */
+
+#ifndef EM_DAEMON_EO_TYPES_H_
+#define EM_DAEMON_EO_TYPES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Daemon EO
+ */
+typedef struct {
+	em_eo_t eo;
+} daemon_eo_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EM_DAEMON_EO_TYPES_H_ */

--- a/src/em_dispatcher.h
+++ b/src/em_dispatcher.h
@@ -101,9 +101,14 @@ call_eo_receive_fn(const em_eo_t eo, const em_receive_func_t eo_receive_func,
 	em_event_type_t event_type = ev_hdr->event_type;
 
 	if (EM_CHECK_LEVEL > 2 &&
-	    unlikely(env_atomic32_get(&ev_hdr->allocated) != 1))
+	    unlikely(env_atomic32_get(&ev_hdr->allocated) != 1)) {
+		const char *eo_name = q_elem->eo_elem == NULL ?
+				      "" : q_elem->eo_elem->name;
 		INTERNAL_ERROR(EM_FATAL(EM_ERR_BAD_STATE), EM_ESCOPE_DISPATCH,
-			       "EO:%" PRI_EO ": received event already freed!");
+			       "EO:%" PRI_EO ":%s Q:%" PRI_QUEUE "\n"
+			       "Event:%" PRI_EVENT " already freed",
+			       eo, eo_name, queue, event);
+	}
 
 	em_locm.current.q_elem = q_elem;
 	/* Check and set core local event group (before dispatch callback(s)) */

--- a/src/em_event.c
+++ b/src/em_event.c
@@ -38,6 +38,14 @@ typedef event_hdr_t _ev_hdr__size_check__arr_t[3];
 COMPILE_TIME_ASSERT(sizeof(_ev_hdr__size_check__arr_t) ==
 		    3 * sizeof(event_hdr_t), EVENT_HDR_SIZE_ERROR2);
 
+/*
+ * Verify the value set for EM_CHECK_LEVEL - this define is set either from
+ * the include/event_machine/platform/event_machine_config.h file or by the
+ * configure.ac option --enable-check-level=N.
+ */
+COMPILE_TIME_ASSERT(EM_CHECK_LEVEL >= 0 && EM_CHECK_LEVEL <= 3,
+		    EM_CHECK_LEVEL__BAD_VALUE);
+
 em_status_t
 event_init(void)
 {
@@ -78,11 +86,12 @@ event_free_multi(em_event_t *const events, const int num)
 							1);
 
 				if (unlikely(allocated != 0)) {
+					const char *const fmt =
+					"Double free:events[%d]:%" PRI_EVENT "";
 					err = EM_FATAL(EM_ERR_BAD_POINTER);
 					escope = EM_ESCOPE_EVENT_FREE_MULTI;
-					INTERNAL_ERROR(err, escope,
-						       "Double free:events[%d]",
-						       i);
+					INTERNAL_ERROR(err, escope, fmt,
+						       i, events[i]);
 				}
 			}
 		}

--- a/src/em_event.h
+++ b/src/em_event.h
@@ -343,6 +343,7 @@ event_alloc_buf(mpool_elem_t *const pool_elem, size_t size,
 	/* For optimization, no initialization for feature variables */
 	ev_hdr->event = em_event;  /* store this event handle */
 	ev_hdr->event_size = size; /* store requested size */
+	ev_hdr->align_offset = pool_elem->align_offset;
 	ev_hdr->event_type = type; /* store the event type */
 	ev_hdr->egrp = EM_EVENT_GROUP_UNDEF;
 
@@ -372,7 +373,7 @@ event_alloc_pkt(mpool_elem_t *const pool_elem, size_t size,
 	odp_event_t odp_event;
 	em_event_t em_event;
 	event_hdr_t *ev_hdr;
-	const uint32_t push_len = em_shm->opt.pool.alloc_align;
+	const uint32_t push_len = pool_elem->align_offset;
 	uint32_t pull_len;
 	size_t alloc_size;
 
@@ -445,6 +446,7 @@ event_alloc_pkt(mpool_elem_t *const pool_elem, size_t size,
 	/* For optimization, no initialization for feature variables */
 	ev_hdr->event = em_event;  /* store this event handle */
 	ev_hdr->event_size = size; /* store requested size */
+	/* ev_hdr->align_offset = needed by odp bufs only */
 	ev_hdr->event_type = type; /* store the event type */
 	ev_hdr->egrp = EM_EVENT_GROUP_UNDEF;
 

--- a/src/em_event_group.h
+++ b/src/em_event_group.h
@@ -224,20 +224,23 @@ event_group_count_decrement(const unsigned int decr)
 		if (EM_EVENT_GROUP_SAFE_MODE)
 			egrp_elem->pre.count = 0;
 
-		int i;
 		const int num_notif = egrp_elem->num_notif;
+		em_status_t ret;
 
 		/* Copy notifications to local memory */
 		em_notif_t notif_tbl[EM_EVENT_GROUP_MAX_NOTIF];
 
-		for (i = 0; i < num_notif; i++) {
+		for (int i = 0; i < num_notif; i++) {
 			notif_tbl[i].event = egrp_elem->notif_tbl[i].event;
 			notif_tbl[i].queue = egrp_elem->notif_tbl[i].queue;
 			notif_tbl[i].egroup = egrp_elem->notif_tbl[i].egroup;
 		}
 
 		egrp_elem->ready = 1;
-		send_notifs(num_notif, notif_tbl);
+		ret = send_notifs(num_notif, notif_tbl);
+		if (unlikely(ret != EM_OK))
+			INTERNAL_ERROR(ret, EM_ESCOPE_EVENT_GROUP_UPDATE,
+				       "send notifs failed");
 	}
 }
 

--- a/src/em_event_types.h
+++ b/src/em_event_types.h
@@ -99,6 +99,13 @@ typedef struct {
 	 */
 	size_t event_size;
 	/**
+	 * Payload alloc alignment offset/push into free area of ev_hdr.
+	 * Only used by events based on ODP buffers that have the ev_hdr in the
+	 * beginning of the buf payload (pkts use 'user-area' for ev_hdr).
+	 * Value is copied from pool_elem->align_offset for easy access.
+	 */
+	uint32_t align_offset;
+	/**
 	 * Queue element for associated queue (for AG or local queue)
 	 */
 	queue_elem_t *q_elem;
@@ -135,8 +142,9 @@ typedef struct {
 	/*
 	 * ! EMPTY SPACE !
 	 * Events based on odp_buffer_t only:
-	 *   - space for alignment adjustments as set by config file option:
-	 *     'pool.alloc_align = 2^x bytes'
+	 *   - space for alignment adjustments as set by
+	 *      a) config file option - 'pool.align_offset' or
+	 *      b) pool config param  - 'em_pool_cfg_t:align_offset{}'
 	 *   - space available:
 	 *         sizeof(event_hdr_t) - offsetof(event_hdr_t, end_hdr_data)
 	 *   - events based on odp_packet_t have their event header in the

--- a/src/em_include.h
+++ b/src/em_include.h
@@ -66,6 +66,7 @@ extern "C" {
 #include "em_init.h"
 
 #include "em_atomic.h"
+#include "em_daemon_eo_types.h"
 #include "em_chaining_types.h"
 #include "em_core_types.h"
 #include "em_error_types.h"
@@ -81,6 +82,7 @@ extern "C" {
 #include "em_sync_api_types.h"
 #include "em_hook_types.h"
 #include "em_libconfig_types.h"
+#include "add-ons/event_timer/em_timer_types.h"
 
 #include "em_mem.h"
 

--- a/src/em_init.h
+++ b/src/em_init.h
@@ -61,7 +61,7 @@ typedef struct {
 typedef struct {
 	struct {
 		int statistics_enable; /* true/false */
-		unsigned int alloc_align; /* bytes */
+		unsigned int align_offset; /* bytes */
 	} pool;
 
 	struct {

--- a/src/em_mem.h
+++ b/src/em_mem.h
@@ -117,6 +117,10 @@ typedef struct {
 	sync_api_t sync_api ENV_CACHE_LINE_ALIGNED;
 	/** Current number of allocated EOs */
 	env_atomic32_t eo_count ENV_CACHE_LINE_ALIGNED;
+	/** Daemon eo */
+	daemon_eo_t daemon ENV_CACHE_LINE_ALIGNED;
+	/** Timer resources */
+	timer_storage_t timers ENV_CACHE_LINE_ALIGNED;
 	/** Current number of allocated queues */
 	env_atomic32_t queue_count;
 	/** Current number of allocated queue groups */
@@ -127,10 +131,8 @@ typedef struct {
 	env_atomic32_t atomic_group_count;
 	/** Current number of allocated event pools */
 	env_atomic32_t pool_count;
-
-	/* libconfig setting, both default (compiled) and runtime (from file) */
+	/** libconfig setting, default (compiled) and runtime (from file) */
 	libconfig_t libconfig;
-
 	/** Guarantee that size is a multiple of cache line size */
 	void *end[0] ENV_CACHE_LINE_ALIGNED;
 } em_shm_t;

--- a/src/em_pool_types.h
+++ b/src/em_pool_types.h
@@ -47,20 +47,22 @@ extern "C" {
 typedef struct {
 	/** EM pool handle */
 	em_pool_t em_pool;
-	/* Pool name */
-	char name[EM_POOL_NAME_LEN];
 	/** Event type of events allocated from the pool */
 	em_event_type_t event_type;
+	/** Subpool alignment requested from ODP */
+	uint32_t align_offset;
 	/** Number of subpools within one EM pool, max=EM_MAX_SUBPOOLS */
 	int num_subpools;
-	/** ODP buffer handles for the subpools  */
-	odp_pool_t odp_pool[EM_MAX_SUBPOOLS];
 	/** ODP (sub)pool buffer (event) payload sizes */
 	uint32_t size[EM_MAX_SUBPOOLS];
+	/** ODP buffer handles for the subpools  */
+	odp_pool_t odp_pool[EM_MAX_SUBPOOLS];
 	/** for linking free pool-entries together */
 	objpool_elem_t objpool_elem;
 	/** Pool Configuration given during create */
 	em_pool_cfg_t pool_cfg;
+	/* Pool name */
+	char name[EM_POOL_NAME_LEN];
 } mpool_elem_t;
 
 typedef struct {

--- a/src/em_queue_group.c
+++ b/src/em_queue_group.c
@@ -236,6 +236,8 @@ default_queue_group_update(void)
 	odp_thrmask_t *odp_thrmask;
 
 	default_qgrp_elem = queue_group_elem_get(EM_QUEUE_GROUP_DEFAULT);
+	if (unlikely(default_qgrp_elem == NULL))
+		return EM_QUEUE_GROUP_UNDEF;
 
 	mask = &default_qgrp_elem->core_mask;
 	em_core_mask_set_count(em_core_count(), mask);
@@ -351,7 +353,7 @@ queue_group_create_sync(const char *name, const em_core_mask_t *mask,
 {
 	return queue_group_create_escope(name, mask, 0, NULL,
 					 requested_queue_group,
-					 EM_ESCOPE_QUEUE_GROUP_CREATE);
+					 EM_ESCOPE_QUEUE_GROUP_CREATE_SYNC);
 }
 
 /**

--- a/src/env/env_sharedmem.c
+++ b/src/env/env_sharedmem.c
@@ -114,6 +114,7 @@ env_shared_free(void *buf)
 {
 	env_shm_buf_t *env_shm_buf;
 	odp_shm_t shm;
+	int ret;
 
 	if (buf == NULL)
 		return;
@@ -122,5 +123,7 @@ env_shared_free(void *buf)
 					offsetof(env_shm_buf_t, data));
 
 	shm = env_shm_buf->hdr.odp_shm;
-	odp_shm_free(shm);
+	ret = odp_shm_free(shm);
+	if (unlikely(ret != 0))
+		env_panic("");
 }

--- a/src/event_machine_eo.c
+++ b/src/event_machine_eo.c
@@ -951,9 +951,8 @@ em_eo_stop_sync(em_eo_t eo)
 eo_stop_sync_error:
 	env_spinlock_unlock(&em_shm->sync_api.lock_global);
 
-	RETURN_ERROR_IF(ret != EM_OK, ret, EM_ESCOPE_EO_STOP_SYNC,
-			"Failure: EO:%" PRI_EO "", eo);
-	return EM_OK;
+	return INTERNAL_ERROR(ret, EM_ESCOPE_EO_STOP_SYNC,
+			      "Failure: EO:%" PRI_EO "", eo);
 }
 
 em_eo_t

--- a/src/event_machine_event_group.c
+++ b/src/event_machine_event_group.c
@@ -281,7 +281,8 @@ em_send_group(em_event_t event, em_queue_t queue,
 	if (EM_CHECK_LEVEL > 2)
 		RETURN_ERROR_IF(env_atomic32_get(&ev_hdr->allocated) != 1,
 				EM_FATAL(EM_ERR_BAD_STATE),
-				EM_ESCOPE_SEND_GROUP, "Event already freed!");
+				EM_ESCOPE_SEND_GROUP,
+				"Event:%" PRI_EVENT " already freed!", event);
 
 	if (!is_external) {
 		/* queue belongs to this EM instance */
@@ -452,9 +453,11 @@ em_send_group_multi(em_event_t *const events, int num, em_queue_t queue,
 		     env_atomic32_get(&ev_hdrs[i]->allocated) == 1; i++)
 			;
 		if (unlikely(i != num)) {
+			const char *const fmt =
+				"events[%d]:%" PRI_EVENT " already freed!";
 			INTERNAL_ERROR(EM_FATAL(EM_ERR_BAD_STATE),
 				       EM_ESCOPE_SEND_GROUP_MULTI,
-				       "Event(s) already freed!");
+				       fmt, i, events[i]);
 			return 0;
 		}
 	}

--- a/src/event_machine_pool.c
+++ b/src/event_machine_pool.c
@@ -180,6 +180,7 @@ em_pool_info(em_pool_t pool, em_pool_info_t *const pool_info /*out*/)
 	pool_info->name[sizeof(pool_info->name) - 1] = '\0';
 	pool_info->em_pool = pool_elem->em_pool;
 	pool_info->event_type = pool_elem->event_type;
+	pool_info->align_offset = pool_elem->align_offset;
 	pool_info->num_subpools = pool_elem->num_subpools;
 	for (int i = 0; i < pool_elem->num_subpools; i++) {
 		uint32_t num = pool_elem->pool_cfg.subpool[i].num;
@@ -215,7 +216,7 @@ em_pool_info(em_pool_t pool, em_pool_info_t *const pool_info /*out*/)
 }
 
 #define POOL_INFO_HDR_STR \
-"  id     name             type        sizes                 (used/free)\n"
+"  id     name             type       offset  sizes                (used/free)\n"
 
 void
 em_pool_info_print(em_pool_t pool)


### PR DESCRIPTION
- Support for EM API v2.2 (em-odp/include), see API changes in
  em-odp/include/event_machine/README_API.
- EM config file options - config/em-odp.conf
    - Option 'pool.align_offset':
      (Replaced 'pool.alloc_align' with 'pool.align_offset')

      Alignment offset in bytes for the event payload start address.
      Set the event payload alignment offset for events allocated from
      any pool. This is a global setting concerning all pools.
      A similar, but pool-secific option, is 'em_pool_cfg_t:align_offset{}'
      that overrides this global setting for a specific pool when given to
      em_pool_create(..., pool_cfg).

      Use this option to globally adjust the payload layout so that a
      specific part of it can be placed at a needed alignment for e.g.
      HW access.

      The default EM event payload start address alignment is a power-of-two
      that is at minimum 32 bytes (i.e. 32 B, 64 B, 128 B etc. depending on
      e.g. target cache-line size).
      The 'align_offset' option can be used to fine-tune the start-address
      by a small offset to e.g. make room for a small SW header before the
      rest of the payload that might need a specific alignment for direct
      HW-access.
      Example: setting 'align_offset = 8' makes sure that the payload
      _after_ 8 bytes will be aligned at minimum (2^x) 32 bytes for all
      pools that do not override this value.

      start: base - align_offset
           |
           v
           +------------------------------------------+
           | <----- |  Event Payload                  |
           +------------------------------------------+
                    ^
                    |
                   base (min 32B aligned, power-of-two)
- New autoconf configure-script options (configure.ac):
    --without-programs
      Build the EM library without example programs
    --with-config-file=FILE
      Override the default EM configuration file (default:config/em-odp.conf)
      that is used during the configure & build phases to generate the built-in
      default values for the EM runtime-config (note that runtime config options
      can further be changed during startup by setting the EM_CONFIG_FILE=file
      variable).
      The overriding file set with --with-config-file=FILE must include all
      EM configuration options (unlike the runtime file that only need to
      include the mandatory and changed options).
    --enable-check-level=VAL(0…3)
      Set the compile-time EM_CHECK_LEVEL,
      see include/event_machine/platform/event_machine_config.h

Signed-off-by: Carl Wallén <carl.wallen@nokia.com>