### PR TITLE
em-odp v2.3.0

### DIFF
--- a/CHANGE_NOTES
+++ b/CHANGE_NOTES
@@ -44,6 +44,23 @@ The version numbering scheme reflects the used EM API version:
 - See em-odp/include/event_machine/README_API for API changes
 
 --------------------------------------------------------------------------------
+Event Machine on ODP v2.3.0
+--------------------------------------------------------------------------------
+- Support for EM API v2.3 (em-odp/include), see API changes in
+  em-odp/include/event_machine/README_API:
+    - Event: multi-event alloc and free functions
+    - Hooks: use the same hook-type for all allocs and the same for all frees
+    - EO: multi-event EO-receive function
+    - Dispatch: one common enter-callback for multi- and single-receive funcs.
+    - Init: core masks for input_poll_fn and output_drain_fn added to em_conf_t
+    - Init: use em_conf_init(em_conf_t *conf) to init the EM config params.
+    - Event: APIs to get the event type(s) of multiple events
+- Fix libemodp symbol visibility, only expose API symbols
+- New example program:     timer_test_periodic
+  New packet-io programs:  loopback_local_multircv, loopback_multircv
+  New performance program: loop_multircv
+
+--------------------------------------------------------------------------------
 Event Machine on ODP v2.2.0
 --------------------------------------------------------------------------------
 - Support for EM API v2.2 (em-odp/include), see API changes in

--- a/README
+++ b/README
@@ -56,10 +56,11 @@ See further configure options: ../configure --help
 > make && make install
 
 Tested against odp linux-generic, commit:
-  Commit: fd9f805a0024677f31876e13d28aa8ab9470a282 [fd9f805]
-  Date: Thursday, 4 June 2020 0:48.15
-  Commit Date: Thursday, 4 June 2020 16:39.27
-  validation: classification: fix duplicate global variable definition
+  Commit: 518bb7cf5c8f35c198f40015d999cce7de0c4365 [518bb7c]
+  Date: Friday, 12 June 2020 15:49.56
+  Commit Date: Friday, 3 July 2020 15:20.24
+  changelog: updates for odp v1.24.0.0
+  Add latest API changes and fixed issues.
 
 Trying to build static test applications without a static ODP library would
 fail.
@@ -162,10 +163,9 @@ ODP compilations as above but different installation directories i.e.
 > ../configure --prefix=<odp-dpdk install path>
 
 Tested against odp-dpdk commit:
-Commit: 102173c31bf1af979488af3d3d4175d162ac0454 [102173c]
-Date: Monday, 11 May 2020 14:59.08
-Commit Date: Wednesday, 13 May 2020 12:30.53
-linux-dpdk: pktio: add configuration option for ethernet multicast receipt
+Commit: aa55e35150da8099ed9f565173993609650010af [aa55e35]
+Date: Friday, 3 July 2020 17:03.49
+Merge ODP v1.24.0.0
 
 EM-ODP compilation with odp-dpdk:
 > mkdir build-dpdk && cd build-dpdk

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_PREREQ([2.69])
 # Version
 ############################
 m4_define([em_api_major_version], [2])
-m4_define([em_api_minor_version], [2])
+m4_define([em_api_minor_version], [3])
 m4_define([em_api_implementation_version], [0])
 m4_define([em_api_implementation_fix], [0])
 
@@ -89,6 +89,13 @@ AC_TYPE_UINT8_T
 AC_TYPE_UINT16_T
 AC_TYPE_UINT32_T
 AC_TYPE_UINT64_T
+
+
+##########################################################################
+# Enable -fvisibility=hidden if CC supports it
+##########################################################################
+EM_VISIBILITY
+# VISIBILITY_CFLAGS set
 
 ##########################################################################
 # Check for pthreads availability

--- a/include/event_machine.h
+++ b/include/event_machine.h
@@ -32,12 +32,13 @@
 #ifndef EVENT_MACHINE_H
 #define EVENT_MACHINE_H
 
+#pragma GCC visibility push(default)
+
 /**
  * @file
- * Event Machine API v2.1
+ * Event Machine API v2.3
  *
  * This file includes all other needed EM headers
- *
  */
 
 #ifdef __cplusplus
@@ -53,7 +54,7 @@ extern "C" {
  * Minor API version number.
  * Updates and additions
  */
-#define EM_API_VERSION_MINOR 2
+#define EM_API_VERSION_MINOR 3
 
 /** @mainpage
  *
@@ -262,4 +263,5 @@ extern "C" {
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_H */

--- a/include/event_machine/README_API
+++ b/include/event_machine/README_API
@@ -3,6 +3,87 @@ OpenEM API Release Notes
 -------------------------------------------------------------------------------
 
 -------------------------------------------------------------------------------
+API 2.3 (EM_API_VERSION_MAJOR=2, EM_API_VERSION_MINOR=3)
+-------------------------------------------------------------------------------
+Not backwards compatible with previous API version, API 2.3 contains modified
+types requiring small changes to older code (see 2, 4 and 5).
+
+1. Event: multi-event alloc and free functions
+   APIs for allocating or freeing multiple events.
+   - em_alloc_multi(): Allocate multiple events.
+     Similar to em_alloc(), but allows allocation of multiple events, with same
+     properties, with one function call.
+     The em_alloc_multi() API function will try to allocate the requested number
+     ('num') of events but may fail to do so, e.g. if the pool has run out of
+     events, and will return the actual number of events that were successfully
+     allocated from the given pool.
+   - em_free_multi(): Free multiple events.
+     Similar to em_free(), but allows freeing of multiple events with one
+     function call.
+   See include/event_machine/api/event_machine_event.h:
+   em_alloc_multi() and em_free_multi()
+
+2. Hooks: use the same hook-type for all alloc():s and the same for all free():s
+   em_api_hook_alloc_t: API-callback hook for em_alloc() and em_alloc_multi().
+   em_api_hook_free_t:  API-callback hook for em_free() and em_free_multi().
+   Note! em_api_hook_alloc_t and em_api_hook_free_t _changed_ in API 2.3
+         to suit both single and multi alloc and frees.
+   See include/event_machine/platform/event_machine_hw_types.h:
+   em_api_hook_alloc_t and em_api_hook_free_t
+
+3. EO: multi-event EO-receive function
+   'em_receive_multi_func_t':
+   Similar to the single-event receive function (em_receive_func_t), except that
+   multiple events can be passed with one call to the EO receive function.
+   A multi-event receive function is taken into use during EO creation with a
+   call to em_eo_create_multircv(...). The maximum number of events that the
+   multi-event EO receive function is prepared to handle can be set with the
+   option 'em_eo_multircv_param_t::max_events' given to em_eo_create_multircv().
+   The EM dispatcher will split event batches larger than 'max_events' into
+   chunks of 'max_events'.
+   Event group handling: All events passed by the EM dispatcher to the
+   EO multi-event receive function belong to the same event group (or none)
+   - a batch of events containing multiple event groups is split by the
+   dispatcher into smaller chunks, each chunk belonging to the same event group
+   (or none). The event group count is decremented by the number of events
+   passed to the receive function when execution returns to the dispatcher.
+   See include/event_machine/api/event_machine_eo.h:
+   em_receive_multi_func_t and em_eo_create_multircv().
+
+4. Dispatch: one common enter-callback for multi- and single-receive funcs.
+   em_dispatch_enter_func_t: the dispatch enter callback, called before entering
+   an EO-receive function, is changed so that one common callback type can be
+   used for both single-event and multi-event EO-receive functions.
+   Note! 'em_dispatch_enter_func_t' _changed_ in EM API v2.3.
+   See include/event_machine/api/event_machine_dispatcher.h:
+   em_dispatch_enter_func_t and em_dispatch_register_enter_cb()
+
+5. Init: core masks for 'input_poll_fn' and 'output_drain_fn' added to em_conf_t
+   Add the 'input_poll_mask' and 'output_drain_mask' fields to em_conf_t.
+   These masks define the logical EM cores on which these functions
+   are executed.
+   Note! New fields added to em_conf_t in API 2.3, user must initialize these
+         added fields - use em_conf_init(), see 6.
+   See include/event_machine/platform/event_machine_init.h:
+   em_conf_t and em_conf_init()
+
+6. Init: use em_conf_init(em_conf_t *conf) to init the EM config params.
+   Using em_conf_init() provides better backwards compatibility since
+   all options will be set to default values before use.
+   All users should call em_conf_init() before calling em_init()!
+   See include/event_machine/platform/event_machine_init.h:
+   em_conf_t and em_conf_init()
+
+7. Event: APIs to get the event type(s) of multiple events
+   Two EM APIs added:
+   - Get the event types of multiple events:
+     em_event_get_type_multi()
+   - Get the number of events that have the same event type:
+     em_event_same_type_multi()
+   See include/event_machine/api/event_machine_event.h:
+   em_event_get_type_multi() and em_event_same_type_multi()
+
+-------------------------------------------------------------------------------
 API 2.2 (EM_API_VERSION_MAJOR=2, EM_API_VERSION_MINOR=2)
 -------------------------------------------------------------------------------
   Backwards compatible with EM 2.1 API with one EXCEPTION:

--- a/include/event_machine/add-ons/event_machine_add-on_error.h
+++ b/include/event_machine/add-ons/event_machine_add-on_error.h
@@ -30,6 +30,8 @@
 #ifndef EVENT_MACHINE_ADD_ON_ERROR_H_
 #define EVENT_MACHINE_ADD_ON_ERROR_H_
 
+#pragma GCC visibility push(default)
+
 #include <event_machine/api/event_machine_types.h>
 
 /**
@@ -52,4 +54,5 @@
 #define EM_ESCOPE_TMO_ACK                   (EM_ESCOPE_ADD_ON_API_BASE | 0x00B)
 #define EM_ESCOPE_TMO_GET_STATE             (EM_ESCOPE_ADD_ON_API_BASE | 0x00C)
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_ADD_ON_ERROR_H_ */

--- a/include/event_machine/add-ons/event_machine_timer.h
+++ b/include/event_machine/add-ons/event_machine_timer.h
@@ -31,6 +31,8 @@
 #ifndef EVENT_MACHINE_TIMER_H_
 #define EVENT_MACHINE_TIMER_H_
 
+#pragma GCC visibility push(default)
+
 /**
  * @file
  *  Event Machine timer add-on
@@ -499,4 +501,5 @@ em_tmo_state_t em_tmo_get_state(em_tmo_t tmo);
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_TIMER_H_ */

--- a/include/event_machine/add-ons/templates/event_machine_timer_hw_specific.h.template
+++ b/include/event_machine/add-ons/templates/event_machine_timer_hw_specific.h.template
@@ -41,6 +41,8 @@
 #ifndef EVENT_MACHINE_TIMER_HW_SPECIFIC_H
 #define EVENT_MACHINE_TIMER_HW_SPECIFIC_H
 
+#pragma GCC visibility push(default)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -116,4 +118,5 @@ typedef enum em_timer_clksrc_t {
 }
 #endif
 
+#pragma GCC visibility pop
 #endif

--- a/include/event_machine/api/event_machine_atomic_group.h
+++ b/include/event_machine/api/event_machine_atomic_group.h
@@ -31,6 +31,8 @@
 #ifndef EVENT_MACHINE_ATOMIC_GROUP_H_
 #define EVENT_MACHINE_ATOMIC_GROUP_H_
 
+#pragma GCC visibility push(default)
+
 /**
  * @file
  * @defgroup em_atomic_group Atomic group
@@ -298,4 +300,5 @@ em_atomic_group_queue_get_next(void);
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_ATOMIC_GROUP_H_ */

--- a/include/event_machine/api/event_machine_core.h
+++ b/include/event_machine/api/event_machine_core.h
@@ -31,6 +31,8 @@
 #ifndef EVENT_MACHINE_CORE_H_
 #define EVENT_MACHINE_CORE_H_
 
+#pragma GCC visibility push(default)
+
 /**
  * @file
  * @defgroup em_core Core related
@@ -79,4 +81,5 @@ em_core_count(void);
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_CORE_H_ */

--- a/include/event_machine/api/event_machine_error.h
+++ b/include/event_machine/api/event_machine_error.h
@@ -31,6 +31,8 @@
 #ifndef EVENT_MACHINE_ERROR_H_
 #define EVENT_MACHINE_ERROR_H_
 
+#pragma GCC visibility push(default)
+
 /**
  * @file
  * @defgroup em_error Error management
@@ -148,4 +150,5 @@ void em_error(em_status_t error, em_escope_t escope, ...);
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_ERROR_H_ */

--- a/include/event_machine/api/event_machine_event_group.h
+++ b/include/event_machine/api/event_machine_event_group.h
@@ -31,6 +31,8 @@
 #ifndef EVENT_MACHINE_EVENT_GROUP_H_
 #define EVENT_MACHINE_EVENT_GROUP_H_
 
+#pragma GCC visibility push(default)
+
 /**
  * @file
  * @defgroup em_event_group Event group
@@ -445,4 +447,5 @@ em_event_group_get_next(void);
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_EVENT_GROUP_H_ */

--- a/include/event_machine/api/event_machine_queue.h
+++ b/include/event_machine/api/event_machine_queue.h
@@ -31,6 +31,8 @@
 #ifndef EVENT_MACHINE_QUEUE_H_
 #define EVENT_MACHINE_QUEUE_H_
 
+#pragma GCC visibility push(default)
+
 /**
  * @file
  * @defgroup em_queue Queues
@@ -464,4 +466,5 @@ em_queue_get_next(void);
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_QUEUE_H_ */

--- a/include/event_machine/api/event_machine_queue_group.h
+++ b/include/event_machine/api/event_machine_queue_group.h
@@ -31,6 +31,8 @@
 #ifndef EVENT_MACHINE_QUEUE_GROUP_H_
 #define EVENT_MACHINE_QUEUE_GROUP_H_
 
+#pragma GCC visibility push(default)
+
 /**
  * @file
  * @defgroup em_queue_group Queue group
@@ -357,4 +359,5 @@ em_queue_group_queue_get_next(void);
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_QUEUE_GROUP_H_ */

--- a/include/event_machine/api/event_machine_scheduler.h
+++ b/include/event_machine/api/event_machine_scheduler.h
@@ -31,6 +31,8 @@
 #ifndef EVENT_MACHINE_SCHEDULER_H_
 #define EVENT_MACHINE_SCHEDULER_H_
 
+#pragma GCC visibility push(default)
+
 /**
  * @file
  * @defgroup em_scheduler Scheduler
@@ -147,4 +149,5 @@ em_sched_context_type_current(em_queue_t *queue);
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_SCHEDULER_H_ */

--- a/include/event_machine/api/event_machine_types.h
+++ b/include/event_machine/api/event_machine_types.h
@@ -32,6 +32,8 @@
 #ifndef EVENT_MACHINE_TYPES_H_
 #define EVENT_MACHINE_TYPES_H_
 
+#pragma GCC visibility push(default)
+
 /**
  * @file
  *
@@ -61,15 +63,18 @@ EM_HANDLE_T(em_event_t);
 #define PRI_EVENT  PRI_HDL
 
 /**
- * Event type. This is given to application for each received
- * event and also needed for event allocation.
- * It's an integer, but split into major and minor part.
- * major-field categorizes the event and minor is
- * more detailed system specific description.
- * Major-part will not change by HW, but minor can be HW/SW platform
- * specific and thus could be split into more sub-fields as needed.
- * Application should use the access functions for reading major
- * and minor part.
+ * @typedef em_event_type_t
+ * Event type
+ *
+ * The event type is given to the EO-receive function for each received event
+ * and is also needed for event allocation. This type is an integer that is
+ * split into major and minor parts:
+ *   1) the major-field categorizes the event and
+ *   2) the minor is a more detailed system specific description.
+ * The major-part will not change by HW, but the minor-part can be
+ * HW/SW platform specific and thus could be split into more sub-fields as
+ * needed. The application should use the access functions for reading major
+ * and minor parts.
  *
  * The only event type with defined content is EM_EVENT_TYPE_SW with
  * minor type 0, which needs to be portable (direct pointer to data).
@@ -411,28 +416,30 @@ typedef uint32_t em_escope_t;
 
 /* EM API escopes: EO */
 #define EM_ESCOPE_EO_CREATE                       (EM_ESCOPE_API_MASK | 0x0301)
-#define EM_ESCOPE_EO_DELETE                       (EM_ESCOPE_API_MASK | 0x0302)
-#define EM_ESCOPE_EO_GET_NAME                     (EM_ESCOPE_API_MASK | 0x0303)
-#define EM_ESCOPE_EO_FIND                         (EM_ESCOPE_API_MASK | 0x0304)
-#define EM_ESCOPE_EO_ADD_QUEUE                    (EM_ESCOPE_API_MASK | 0x0305)
-#define EM_ESCOPE_EO_ADD_QUEUE_SYNC               (EM_ESCOPE_API_MASK | 0x0306)
-#define EM_ESCOPE_EO_REMOVE_QUEUE                 (EM_ESCOPE_API_MASK | 0x0307)
-#define EM_ESCOPE_EO_REMOVE_QUEUE_SYNC            (EM_ESCOPE_API_MASK | 0x0308)
-#define EM_ESCOPE_EO_REMOVE_QUEUE_ALL             (EM_ESCOPE_API_MASK | 0x0309)
-#define EM_ESCOPE_EO_REMOVE_QUEUE_ALL_SYNC        (EM_ESCOPE_API_MASK | 0x030A)
-#define EM_ESCOPE_EO_REGISTER_ERROR_HANDLER       (EM_ESCOPE_API_MASK | 0x030B)
-#define EM_ESCOPE_EO_UNREGISTER_ERROR_HANDLER     (EM_ESCOPE_API_MASK | 0x030C)
-#define EM_ESCOPE_EO_START                        (EM_ESCOPE_API_MASK | 0x030D)
-#define EM_ESCOPE_EO_START_SYNC                   (EM_ESCOPE_API_MASK | 0x030E)
-#define EM_ESCOPE_EO_STOP                         (EM_ESCOPE_API_MASK | 0x030F)
-#define EM_ESCOPE_EO_STOP_SYNC                    (EM_ESCOPE_API_MASK | 0x0310)
-#define EM_ESCOPE_EO_CURRENT                      (EM_ESCOPE_API_MASK | 0x0311)
-#define EM_ESCOPE_EO_GET_CONTEXT                  (EM_ESCOPE_API_MASK | 0x0312)
-#define EM_ESCOPE_EO_GET_FIRST                    (EM_ESCOPE_API_MASK | 0x0313)
-#define EM_ESCOPE_EO_GET_NEXT                     (EM_ESCOPE_API_MASK | 0x0314)
-#define EM_ESCOPE_EO_GET_STATE                    (EM_ESCOPE_API_MASK | 0x0315)
-#define EM_ESCOPE_EO_QUEUE_GET_FIRST              (EM_ESCOPE_API_MASK | 0x0316)
-#define EM_ESCOPE_EO_QUEUE_GET_NEXT               (EM_ESCOPE_API_MASK | 0x0317)
+#define EM_ESCOPE_EO_CREATE_MULTIRCV              (EM_ESCOPE_API_MASK | 0x0302)
+#define EM_ESCOPE_EO_MULTIRCV_PARAM_INIT          (EM_ESCOPE_API_MASK | 0x0303)
+#define EM_ESCOPE_EO_DELETE                       (EM_ESCOPE_API_MASK | 0x0304)
+#define EM_ESCOPE_EO_GET_NAME                     (EM_ESCOPE_API_MASK | 0x0305)
+#define EM_ESCOPE_EO_FIND                         (EM_ESCOPE_API_MASK | 0x0306)
+#define EM_ESCOPE_EO_ADD_QUEUE                    (EM_ESCOPE_API_MASK | 0x0307)
+#define EM_ESCOPE_EO_ADD_QUEUE_SYNC               (EM_ESCOPE_API_MASK | 0x0308)
+#define EM_ESCOPE_EO_REMOVE_QUEUE                 (EM_ESCOPE_API_MASK | 0x0309)
+#define EM_ESCOPE_EO_REMOVE_QUEUE_SYNC            (EM_ESCOPE_API_MASK | 0x030A)
+#define EM_ESCOPE_EO_REMOVE_QUEUE_ALL             (EM_ESCOPE_API_MASK | 0x030B)
+#define EM_ESCOPE_EO_REMOVE_QUEUE_ALL_SYNC        (EM_ESCOPE_API_MASK | 0x030C)
+#define EM_ESCOPE_EO_REGISTER_ERROR_HANDLER       (EM_ESCOPE_API_MASK | 0x030D)
+#define EM_ESCOPE_EO_UNREGISTER_ERROR_HANDLER     (EM_ESCOPE_API_MASK | 0x030E)
+#define EM_ESCOPE_EO_START                        (EM_ESCOPE_API_MASK | 0x030F)
+#define EM_ESCOPE_EO_START_SYNC                   (EM_ESCOPE_API_MASK | 0x0310)
+#define EM_ESCOPE_EO_STOP                         (EM_ESCOPE_API_MASK | 0x0311)
+#define EM_ESCOPE_EO_STOP_SYNC                    (EM_ESCOPE_API_MASK | 0x0312)
+#define EM_ESCOPE_EO_CURRENT                      (EM_ESCOPE_API_MASK | 0x0313)
+#define EM_ESCOPE_EO_GET_CONTEXT                  (EM_ESCOPE_API_MASK | 0x0314)
+#define EM_ESCOPE_EO_GET_FIRST                    (EM_ESCOPE_API_MASK | 0x0315)
+#define EM_ESCOPE_EO_GET_NEXT                     (EM_ESCOPE_API_MASK | 0x0316)
+#define EM_ESCOPE_EO_GET_STATE                    (EM_ESCOPE_API_MASK | 0x0317)
+#define EM_ESCOPE_EO_QUEUE_GET_FIRST              (EM_ESCOPE_API_MASK | 0x0318)
+#define EM_ESCOPE_EO_QUEUE_GET_NEXT               (EM_ESCOPE_API_MASK | 0x0319)
 
 /* EM API escopes: Error */
 #define EM_ESCOPE_REGISTER_ERROR_HANDLER          (EM_ESCOPE_API_MASK | 0x0401)
@@ -457,13 +464,17 @@ typedef uint32_t em_escope_t;
 
 /* EM API escopes: Event */
 #define EM_ESCOPE_ALLOC                           (EM_ESCOPE_API_MASK | 0x0601)
-#define EM_ESCOPE_FREE                            (EM_ESCOPE_API_MASK | 0x0602)
-#define EM_ESCOPE_SEND                            (EM_ESCOPE_API_MASK | 0x0603)
-#define EM_ESCOPE_SEND_MULTI                      (EM_ESCOPE_API_MASK | 0x0604)
-#define EM_ESCOPE_EVENT_POINTER                   (EM_ESCOPE_API_MASK | 0x0605)
-#define EM_ESCOPE_EVENT_GET_SIZE                  (EM_ESCOPE_API_MASK | 0x0606)
-#define EM_ESCOPE_EVENT_SET_TYPE                  (EM_ESCOPE_API_MASK | 0x0607)
-#define EM_ESCOPE_EVENT_GET_TYPE                  (EM_ESCOPE_API_MASK | 0x0608)
+#define EM_ESCOPE_ALLOC_MULTI                     (EM_ESCOPE_API_MASK | 0x0602)
+#define EM_ESCOPE_FREE                            (EM_ESCOPE_API_MASK | 0x0603)
+#define EM_ESCOPE_FREE_MULTI                      (EM_ESCOPE_API_MASK | 0x0604)
+#define EM_ESCOPE_SEND                            (EM_ESCOPE_API_MASK | 0x0605)
+#define EM_ESCOPE_SEND_MULTI                      (EM_ESCOPE_API_MASK | 0x0606)
+#define EM_ESCOPE_EVENT_POINTER                   (EM_ESCOPE_API_MASK | 0x0607)
+#define EM_ESCOPE_EVENT_GET_SIZE                  (EM_ESCOPE_API_MASK | 0x0608)
+#define EM_ESCOPE_EVENT_SET_TYPE                  (EM_ESCOPE_API_MASK | 0x0609)
+#define EM_ESCOPE_EVENT_GET_TYPE                  (EM_ESCOPE_API_MASK | 0x060A)
+#define EM_ESCOPE_EVENT_GET_TYPE_MULTI            (EM_ESCOPE_API_MASK | 0x060B)
+#define EM_ESCOPE_EVENT_SAME_TYPE_MULTI           (EM_ESCOPE_API_MASK | 0x060C)
 
 /* EM API escopes: Queue Group */
 #define EM_ESCOPE_QUEUE_GROUP_CREATE              (EM_ESCOPE_API_MASK | 0x0701)
@@ -510,4 +521,5 @@ typedef uint32_t em_escope_t;
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_TYPES_H_ */

--- a/include/event_machine/helper/event_machine_helper.h
+++ b/include/event_machine/helper/event_machine_helper.h
@@ -32,6 +32,8 @@
 #ifndef EVENT_MACHINE_HELPER_H_
 #define EVENT_MACHINE_HELPER_H_
 
+#pragma GCC visibility push(default)
+
 /**
  * @file
  * Event Machine helper functions and macros
@@ -96,4 +98,5 @@ em_core_mask_get_physical(em_core_mask_t *phys, const em_core_mask_t *logic);
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_HELPER_H_ */

--- a/include/event_machine/platform/add-ons/event_machine_timer_hw_specific.h
+++ b/include/event_machine/platform/add-ons/event_machine_timer_hw_specific.h
@@ -35,6 +35,8 @@
 #ifndef EVENT_MACHINE_TIMER_HW_SPECIFIC_H
 #define EVENT_MACHINE_TIMER_HW_SPECIFIC_H
 
+#pragma GCC visibility push(default)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -115,4 +117,5 @@ typedef enum em_timer_clksrc_t {
 }
 #endif
 
+#pragma GCC visibility pop
 #endif

--- a/include/event_machine/platform/env/env_atomic.h
+++ b/include/event_machine/platform/env/env_atomic.h
@@ -29,11 +29,14 @@
  */
 
 /*
- * env helper include file - don't include this file directly
+ * env helper include file - don't include this file directly,
+ * instead #include "environment.h"
  */
 
 #ifndef _ENV_ATOMIC_H_
 #define _ENV_ATOMIC_H_
+
+#pragma GCC visibility push(default)
 
 /*
  * Atomic operations - types & functions
@@ -279,4 +282,5 @@ env_atomic64_cnt_bits(env_atomic64_t *atom)
 	return __builtin_popcountll(env_atomic64_get(atom));
 }
 
+#pragma GCC visibility pop
 #endif /* _ENV_ATOMIC_H_ */

--- a/include/event_machine/platform/env/env_barrier.h
+++ b/include/event_machine/platform/env/env_barrier.h
@@ -36,6 +36,8 @@
 #ifndef _ENV_BARRIER_H_
 #define _ENV_BARRIER_H_
 
+#pragma GCC visibility push(default)
+
 /*
  * Types
  */
@@ -57,4 +59,5 @@ static inline void env_barrier_sync(env_barrier_t *barrier)
 	odp_barrier_wait(barrier);
 }
 
+#pragma GCC visibility pop
 #endif /* _ENV_BARRIER_H_ */

--- a/include/event_machine/platform/env/env_bitmask.h
+++ b/include/event_machine/platform/env/env_bitmask.h
@@ -30,12 +30,14 @@
 
 /**
  * @file
- * Env bit mask functions.
- *
+ * Env bit mask functions - don't include this file directly,
+ * instead #include "environment.h"
  */
 
 #ifndef _ENV_BITMASK_H_
 #define _ENV_BITMASK_H_
+
+#pragma GCC visibility push(default)
 
 #ifdef __cplusplus
 extern "C" {
@@ -298,4 +300,5 @@ static inline void env_bitmask_xor(env_bitmask_t *dst,
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* _ENV_BITMASK_H_ */

--- a/include/event_machine/platform/env/env_conf.h
+++ b/include/event_machine/platform/env/env_conf.h
@@ -36,8 +36,11 @@
 #ifndef _ENV_CONF_H_
 #define _ENV_CONF_H_
 
+#pragma GCC visibility push(default)
+
 #if !(defined(ENV_64_BIT) || defined(ENV_32_BIT))
   #error Missing architecture definition. Define ENV_64_BIT or ENV_32_BIT!
 #endif
 
+#pragma GCC visibility pop
 #endif

--- a/include/event_machine/platform/env/env_macros.h
+++ b/include/event_machine/platform/env/env_macros.h
@@ -36,6 +36,8 @@
 #ifndef _ENV_MACROS_H_
 #define _ENV_MACROS_H_
 
+#pragma GCC visibility push(default)
+
 /**
  * Branch Prediction macros
  */
@@ -62,4 +64,5 @@
 /** Clear the lowest bit of 'n' */
 #define ENV_CLEAR_LOWEST_BIT(n)  ((n) & ((n) - 1))
 
+#pragma GCC visibility pop
 #endif

--- a/include/event_machine/platform/env/env_sharedmem.h
+++ b/include/event_machine/platform/env/env_sharedmem.h
@@ -36,6 +36,8 @@
 #ifndef _ENV_SHAREDMEM_H_
 #define _ENV_SHAREDMEM_H_
 
+#pragma GCC visibility push(default)
+
 /**
  * Shared memory allocation routines
  */
@@ -81,4 +83,5 @@ void *env_shared_malloc(size_t size);
  */
 void env_shared_free(void *buf);
 
+#pragma GCC visibility pop
 #endif /* _ENV_SHAREDMEM_H_ */

--- a/include/event_machine/platform/env/env_spinlock.h
+++ b/include/event_machine/platform/env/env_spinlock.h
@@ -36,6 +36,8 @@
 #ifndef _ENV_SPINLOCK_H_
 #define _ENV_SPINLOCK_H_
 
+#pragma GCC visibility push(default)
+
 typedef odp_spinlock_t env_spinlock_t;
 
 static inline void
@@ -68,4 +70,5 @@ env_spinlock_unlock(env_spinlock_t *const lock)
 	odp_spinlock_unlock((odp_spinlock_t *)lock);
 }
 
+#pragma GCC visibility pop
 #endif /* _ENV_SPINLOCK_H_ */

--- a/include/event_machine/platform/env/env_time.h
+++ b/include/event_machine/platform/env/env_time.h
@@ -30,12 +30,14 @@
 
 /**
  * @file
- * Env time functions.
- *
+ * Env time functions - don't include this file directly,
+ * instead #include "environment.h"
  */
 
 #ifndef _ENV_TIME_H_
 #define _ENV_TIME_H_
+
+#pragma GCC visibility push(default)
 
 #ifdef __cplusplus
 extern "C" {
@@ -187,4 +189,5 @@ static inline uint64_t env_time_to_cycles(env_time_t time, uint64_t hz)
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* _ENV_TIME_H_ */

--- a/include/event_machine/platform/env/environment.h
+++ b/include/event_machine/platform/env/environment.h
@@ -31,11 +31,12 @@
 #ifndef _ENVIRONMENT_H_
 #define _ENVIRONMENT_H_
 
+#pragma GCC visibility push(default)
+
 /**
  * @file
  *
  * Environment header file
- *
  */
 
 #ifdef __cplusplus
@@ -115,4 +116,5 @@ static inline uint64_t env_core_hz(void)
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* _ENVIRONMENT_H_ */

--- a/include/event_machine/platform/event_machine_config.h
+++ b/include/event_machine/platform/event_machine_config.h
@@ -33,11 +33,12 @@
  * @file
  *
  * Event Machine configuration options
- *
  */
 
 #ifndef EVENT_MACHINE_CONFIG_H
 #define EVENT_MACHINE_CONFIG_H
+
+#pragma GCC visibility push(default)
 
 #ifdef __cplusplus
 extern "C" {
@@ -201,4 +202,5 @@ extern "C" {
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_CONFIG_H */

--- a/include/event_machine/platform/event_machine_hooks.h
+++ b/include/event_machine/platform/event_machine_hooks.h
@@ -31,6 +31,8 @@
 #ifndef EVENT_MACHINE_HOOKS_H_
 #define EVENT_MACHINE_HOOKS_H_
 
+#pragma GCC visibility push(default)
+
 /**
  * @file
  * @defgroup em_hooks API-hooks
@@ -147,4 +149,5 @@ em_hooks_unregister_send(em_api_hook_send_t func);
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_HOOKS_H_ */

--- a/include/event_machine/platform/event_machine_hw_config.h
+++ b/include/event_machine/platform/event_machine_hw_config.h
@@ -41,6 +41,8 @@
 #ifndef EVENT_MACHINE_HW_CONFIG_H
 #define EVENT_MACHINE_HW_CONFIG_H
 
+#pragma GCC visibility push(default)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -181,6 +183,16 @@ extern "C" {
 #define EM_SCHED_AG_MULTI_MAX_BURST  32
 
 /**
+ * @def EM_EO_MULTIRCV_MAX_EVENTS
+ * The default maximum number of events passed to the EO's multi-event
+ * receive function (when the EO has been created with em_eo_create_multircv()).
+ * This value is used by EM as a default if the the user does not specify
+ * a value (i.e. gives '0') for 'em_eo_multircv_param_t::max_events' when
+ * calling em_eo_create_multircv()
+ */
+#define EM_EO_MULTIRCV_MAX_EVENTS  32
+
+/**
  * @def EM_OUTPUT_QUEUE_IMMEDIATE
  *   '0': allow EM to buffer events sent to output queues before calling the
  *        user provided output callback to improve throughput
@@ -196,4 +208,5 @@ extern "C" {
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_HW_CONFIG_H */

--- a/include/event_machine/platform/event_machine_hw_specific.h
+++ b/include/event_machine/platform/event_machine_hw_specific.h
@@ -32,11 +32,12 @@
  * @file
  *
  * Event Machine HW specific functions and other additions.
- *
  */
 
 #ifndef EVENT_MACHINE_HW_SPECIFIC_H
 #define EVENT_MACHINE_HW_SPECIFIC_H
+
+#pragma GCC visibility push(default)
 
 #ifdef __cplusplus
 extern "C" {
@@ -285,4 +286,5 @@ em_core_mask_xor(em_core_mask_t *dst, const em_core_mask_t *src1,
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_HW_SPECIFIC_H */

--- a/include/event_machine/platform/event_machine_init.h
+++ b/include/event_machine/platform/event_machine_init.h
@@ -31,6 +31,8 @@
 #ifndef EVENT_MACHINE_INIT_H_
 #define EVENT_MACHINE_INIT_H_
 
+#pragma GCC visibility push(default)
+
 /**
  * @file
  * @defgroup init Initialization and termination
@@ -57,6 +59,175 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * Event Machine run-time configuration options given at startup to em_init()
+ *
+ * The 'em_conf_t' struct should be initialized with em_conf_init() before use.
+ * This initialization provides better backwards compatibility since all options
+ * will be set to default values.
+ * The user must further set the needed configuration and call em_init():
+ *
+ * @code
+ *	em_conf_t conf;
+ *	em_conf_init(&conf); // init with default values
+ *	conf.thread_per_core = 1;
+ *	...
+ *	conf.core_count = N;
+ *	conf.phys_mask = set N bits; // use em_core_mask_...() functions to set
+ *	...
+ *	ret = em_init(&conf); // on one core
+ *	...
+ *	ret = em_init_core(); // on each of the 'conf.core_count' cores
+ * @endcode
+ *
+ * Content is copied into EM by em_init().
+ *
+ * @note Several EM options are configured through compile-time defines.
+ *       Run-time options allow using the same EM-lib with different configs.
+ *       Also see the overrideable EM runtime config file values,
+ *       default file: config/em-odp.config
+ *
+ * @see em_conf_init(), em_init()
+ */
+typedef struct {
+	/**
+	 * EM device id - use different device ids for each EM instance or
+	 * remote EM device that need to communicate with each other.
+	 * Default value is 0.
+	 */
+	uint16_t device_id;
+
+	/**
+	 * Event Timer: enable=1, disable=0.
+	 * Default value is 0 (disable).
+	 */
+	int event_timer;
+
+	/**
+	 * RunMode: EM run with one thread per core.
+	 * Set 'true' to select thread-per-core mode.
+	 * This is the recommended mode, but the user must explicitly set it to
+	 * enable. Default value is 0.
+	 * @note The user must set either 'thread_per_core' or
+	 *       'process_per_core' but not both.
+	 */
+	int thread_per_core;
+
+	/**
+	 * RunMode: EM run with one process per core.
+	 * Set 'true' to select process-per-core mode. Default value is 0.
+	 * @note The user must set either 'thread_per_core' or
+	 *       'process_per_core' but not both.
+	 */
+	int process_per_core;
+
+	/**
+	 * Number of EM-cores (== number of EM-threads or EM-processes).
+	 * The 'core_count' must match the number of bits set in 'phys_mask'.
+	 * EM-cores will be enumerated from 0 to 'core_count-1' regardless of
+	 * the actual physical core ids.
+	 * Default value is 0 and needs to be changed by the user.
+	 */
+	int core_count;
+
+	/**
+	 * Physical core mask, exactly listing the physical CPU cores to be used
+	 * by EM (this is a physical core mask even though the 'em_core_mask_t'
+	 * type is used).
+	 * Default value is all-0 and needs to be changed by the user.
+	 * @note EM otherwise operates on logical cores, i.e. enumerated
+	 *       contiguously from 0 to 'core_count-1' and a logical
+	 *       EM core mask has 'core_count' consequtively set bits.
+	 *       Example - physical mask vs. corresponding EM core mask:
+	 *          .core_count = 8
+	 *          .physmask: 0xf0f0 (binary: 1111 0000 1111 0000 - 8 set bits)
+	 *                     = 8 phys-cores (phys-cores 4-7,12-15)
+	 *       ==> EM-mask:  0x00ff (0000 0000 1111 1111 binary) - 8 EM cores
+	 *                     = 8 EM-cores (EM-cores 0-7)
+	 */
+	em_core_mask_t phys_mask;
+
+	/**
+	 * Pool configuration for the EM default pool (EM_POOL_DEFAULT).
+	 * Default value is all-0 and needs to be changed by the user.
+	 */
+	em_pool_cfg_t default_pool_cfg;
+
+	/**
+	 * EM log functions.
+	 * Default values are NULL and causes EM to use internal default
+	 * log-functions.
+	 */
+	struct {
+		/** EM log function, user overridable, variable number of args*/
+		em_log_func_t log_fn;
+		/** EM log function, user overridable, va_list */
+		em_vlog_func_t vlog_fn;
+	} log;
+
+	/** EM event/pkt input related functions and config */
+	struct {
+		/**
+		 * User provided function, called from within the EM-dispatch
+		 * loop, mainly for polling various input sources for events or
+		 * pkts and then enqueue them into EM.
+		 * Set to 'NULL' if not needed (default).
+		 */
+		em_input_poll_func_t input_poll_fn;
+		/**
+		 * EM core mask to control which EM-cores (0 to 'core_count-1')
+		 * input_poll_fn() will be called on.
+		 * The provided mask has to be equal or a subset of the
+		 * EM core mask with all 'core_count' bits set.
+		 * A zero mask means execution on _all_ EM cores (default).
+		 */
+		em_core_mask_t input_poll_mask;
+	} input;
+
+	/** EM event/pkt output related functions and config */
+	struct {
+		/**
+		 * User provided function, called from within the EM-dispatch
+		 * loop, mainly for 'periodical' draining of buffered output to
+		 * make sure events/pkts are eventually sent out even if the
+		 * rate is low or stops for a while.
+		 * Set to 'NULL' if not needed (default).
+		 */
+		em_output_drain_func_t output_drain_fn;
+		/**
+		 * EM core mask to control which EM-cores (0 to 'core_count-1')
+		 * output_drain_fn() will be called on.
+		 * The provided mask has to be equal or a subset of the
+		 * EM core mask with all 'core_count' bits set.
+		 * A zero mask means execution on _all_ EM cores (default).
+		 */
+		em_core_mask_t output_drain_mask;
+	} output;
+
+	/**
+	 * User provided API callback hooks.
+	 * Set only the needed hooks to avoid performance degradation.
+	 * Only used if EM_API_HOOKS_ENABLE != 0
+	 */
+	em_api_hooks_t api_hooks;
+
+} em_conf_t;
+
+/**
+ * Initialize configuration parameters for em_init()
+ *
+ * Initialize em_conf_t to default values for all fields.
+ * After initialization, the user further needs to set the mandatory fields of
+ * 'em_conf_t' before calling em_init().
+ * Always initialize 'conf' first with em_conf_init(&conf) to
+ * ensure backwards compatibility with potentially added new options.
+ *
+ * @param param   Address of the em_conf_t to be initialized
+ *
+ * @see em_init()
+ */
+void em_conf_init(em_conf_t *conf);
 
 /**
  * Initialize the Event Machine.
@@ -124,4 +295,5 @@ em_term_core(void);
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_INIT_H_ */

--- a/include/event_machine/platform/event_machine_odp_ext.h
+++ b/include/event_machine/platform/event_machine_odp_ext.h
@@ -38,6 +38,8 @@
 #ifndef EVENT_MACHINE_ODP_EXT_H
 #define EVENT_MACHINE_ODP_EXT_H
 
+#pragma GCC visibility push(default)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -119,4 +121,5 @@ pkt_enqueue(odp_packet_t pkt_tbl[], const int num, const em_queue_t queue);
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_ODP_EXT_H */

--- a/include/event_machine/platform/event_machine_pool.h
+++ b/include/event_machine/platform/event_machine_pool.h
@@ -31,6 +31,8 @@
 #ifndef EVENT_MACHINE_POOL_H_
 #define EVENT_MACHINE_POOL_H_
 
+#pragma GCC visibility push(default)
+
 /**
  * @file
  * @defgroup em_pool Event Pool
@@ -219,4 +221,5 @@ em_pool_info_print_all(void);
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_POOL_H_ */

--- a/include/event_machine/platform/templates/event_machine_config.h.template
+++ b/include/event_machine/platform/templates/event_machine_config.h.template
@@ -33,11 +33,12 @@
  * @file
  *
  * Event Machine configuration options
- *
  */
 
 #ifndef EVENT_MACHINE_CONFIG_H
 #define EVENT_MACHINE_CONFIG_H
+
+#pragma GCC visibility push(default)
 
 #ifdef __cplusplus
 extern "C" {
@@ -195,4 +196,5 @@ extern "C" {
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_CONFIG_H */

--- a/include/event_machine/platform/templates/event_machine_hooks.h.template
+++ b/include/event_machine/platform/templates/event_machine_hooks.h.template
@@ -31,6 +31,8 @@
 #ifndef EVENT_MACHINE_HOOKS_H_
 #define EVENT_MACHINE_HOOKS_H_
 
+#pragma GCC visibility push(default)
+
 /**
  * @file
  * @defgroup em_hooks API-hooks
@@ -147,4 +149,5 @@ em_hooks_unregister_send(em_api_hook_send_t func);
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_HOOKS_H_ */

--- a/include/event_machine/platform/templates/event_machine_hw_config.h.template
+++ b/include/event_machine/platform/templates/event_machine_hw_config.h.template
@@ -41,6 +41,8 @@
 #ifndef EVENT_MACHINE_HW_CONFIG_H
 #define EVENT_MACHINE_HW_CONFIG_H
 
+#pragma GCC visibility push(default)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -193,4 +195,5 @@ extern "C" {
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_HW_CONFIG_H */

--- a/include/event_machine/platform/templates/event_machine_hw_specific.h.template
+++ b/include/event_machine/platform/templates/event_machine_hw_specific.h.template
@@ -33,11 +33,12 @@
  * @file
  *
  * Event Machine HW specific functions and other additions.
- *
  */
 
 #ifndef EVENT_MACHINE_HW_SPECIFIC_H
 #define EVENT_MACHINE_HW_SPECIFIC_H
+
+#pragma GCC visibility push(default)
 
 #ifdef __cplusplus
 extern "C" {
@@ -286,4 +287,5 @@ em_core_mask_xor(em_core_mask_t *dst, const em_core_mask_t *src1,
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_HW_SPECIFIC_H */

--- a/include/event_machine/platform/templates/event_machine_hw_types.h.template
+++ b/include/event_machine/platform/templates/event_machine_hw_types.h.template
@@ -33,11 +33,12 @@
  * @file
  *
  * Event Machine HW specific types
- *
  */
 
 #ifndef EVENT_MACHINE_HW_TYPES_H
 #define EVENT_MACHINE_HW_TYPES_H
+
+#pragma GCC visibility push(default)
 
 #ifdef __cplusplus
 extern "C" {
@@ -228,6 +229,11 @@ typedef add_core_mask_type_here em_core_mask_t;
 
 /**
  * EM pool configuration
+ *
+ * Configuration of an EM event pool consisting of up to 'EM_MAX_SUBPOOLS'
+ * subpools, each supporting a specific event payload size. Event allocation,
+ * i.e. em_alloc(), will use the subpool that provides the best fit for the
+ * requested size.
  */
 typedef struct {
 	/**
@@ -237,12 +243,48 @@ typedef struct {
 	 * @note Only major types are considered here, setting minor is error
 	 */
 	em_event_type_t event_type;
-	/** Number of subpools within one EM pool, max=EM_MAX_SUBPOOLS */
+	/**
+	 * Alignment offset in bytes for the event payload start address
+	 * (for all events allocated from this EM pool).
+	 *
+	 * The default EM event payload start address alignment is a
+	 * power-of-two that is at minimum 32 bytes (i.e. 32 B, 64 B, 128 B etc.
+	 * depending on e.g. target cache-line size).
+	 * The 'align_offset.value' option can be used to fine-tune the
+	 * start-address by a small offset to e.g. make room for a small
+	 * SW header before the rest of the payload that might need a specific
+	 * alignment for direct HW-access.
+	 * Example: setting 'align_offset.value = 8' makes sure that the payload
+	 * _after_ 8 bytes will be aligned at minimum (2^x) 32 bytes.
+	 *
+	 * This option conserns all events allocated from the pool and overrides
+	 * the global config file option 'pool.align_offset' for this pool.
+	 */
+	struct {
+		/**
+		 * Select: Use pool-specific align-offset 'value' from below or
+		 *         use the global default value from the config file.
+		 * false (0): Use default value from the config file.
+		 * true (not 0): Use pool specific value set below.
+		 */
+		int in_use;
+		/**
+		 * Pool-specific event payload alignment offset value in bytes
+		 * (only evaluated if 'in_use=true').
+		 * Overrides the config file value for this pool.
+		 * The given 'value' must be a small power-of-two: 2, 4, or 8
+		 * 0: Explicitly set 'No align offset' for the pool.
+		 */
+		uint32_t value;
+	} align_offset;
+	/**
+	 * Number of subpools within one EM pool, max=EM_MAX_SUBPOOLS
+	 */
 	int num_subpools;
 	struct {
-		/** Event payload size of the subpool */
+		/** Event payload size of the subpool (size > 0)  */
 		uint32_t size;
-		/** Number of events in the subpool */
+		/** Number of events in the subpool (num > 0) */
 		uint32_t num;
 	} subpool[EM_MAX_SUBPOOLS];
 } em_pool_cfg_t;
@@ -257,6 +299,8 @@ typedef struct {
 	em_pool_t em_pool;
 	/** Event type of events allocated from the pool */
 	em_event_type_t event_type;
+	/** Event payload alignment offset for events from the pool */
+	uint32_t align_offset;
 	/** Number of subpools within one EM pool, max=EM_MAX_SUBPOOLS */
 	int num_subpools;
 	struct {
@@ -732,4 +776,5 @@ typedef struct {
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_HW_TYPES_H */

--- a/include/event_machine/platform/templates/event_machine_init.h.template
+++ b/include/event_machine/platform/templates/event_machine_init.h.template
@@ -31,6 +31,8 @@
 #ifndef EVENT_MACHINE_INIT_H_
 #define EVENT_MACHINE_INIT_H_
 
+#pragma GCC visibility push(default)
+
 /**
  * @file
  * @defgroup init Initialization and termination
@@ -124,4 +126,5 @@ em_term_core(void);
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_INIT_H_ */

--- a/include/event_machine/platform/templates/event_machine_pool.h.template
+++ b/include/event_machine/platform/templates/event_machine_pool.h.template
@@ -31,6 +31,8 @@
 #ifndef EVENT_MACHINE_POOL_H_
 #define EVENT_MACHINE_POOL_H_
 
+#pragma GCC visibility push(default)
+
 /**
  * @file
  * @defgroup em_pool Event Pool
@@ -219,4 +221,5 @@ em_pool_info_print_all(void);
 }
 #endif
 
+#pragma GCC visibility pop
 #endif /* EVENT_MACHINE_POOL_H_ */

--- a/m4/em_visibility.m4
+++ b/m4/em_visibility.m4
@@ -1,0 +1,21 @@
+# EM_VISIBILITY
+# --------------
+# Enable -fvisibility=hidden if using a gcc that supports it
+
+AC_DEFUN([EM_VISIBILITY], [dnl
+	AC_LANG_PUSH([C])
+	VISIBILITY_CFLAGS="-fvisibility=hidden"
+	AC_CACHE_CHECK([whether $CC supports -fvisibility=hidden],
+		       [em_cv_visibility_hidden], [dnl
+		OLD_CFLAGS="$CFLAGS"
+		CFLAGS="$CFLAGS $VISIBILITY_CFLAGS"
+		AC_LINK_IFELSE([AC_LANG_PROGRAM()],
+			       [em_cv_visibility_hidden=yes],
+			       [em_cv_visibility_hidden=no])
+		CFLAGS=$OLD_CFLAGS
+	])
+	AS_IF([test "x$em_cv_visibility_hidden" != "xyes"],
+	      [VISIBILITY_CFLAGS=""])
+	AC_LANG_POP([C])
+	AC_SUBST(VISIBILITY_CFLAGS)
+]) # EM_VISIBILITY

--- a/programs/common/cm_pktio.h
+++ b/programs/common/cm_pktio.h
@@ -70,7 +70,7 @@ extern "C" {
  * @def MAX_PKT_BURST_TX
  * @brief Maximum number of packets bursted onto a pktout queue
  */
-#define MAX_PKT_BURST_TX  16
+#define MAX_PKT_BURST_TX  32
 
 /**
  * @def MAX_TX_BURST_BUFS

--- a/programs/common/cm_setup.c
+++ b/programs/common/cm_setup.c
@@ -182,8 +182,10 @@ cm_setup(int argc, char *argv[])
 		APPL_EXIT_FAILURE("setvbuf() fails (errno(%i)=%s)",
 				  errno, strerror(errno));
 
+	/* Init the EM conf params */
+	em_conf_init(&em_conf_parse);
+
 	/* Parse the command line arguments */
-	memset(&em_conf_parse, 0, sizeof(em_conf_parse));
 	memset(&appl_conf_parse, 0, sizeof(appl_conf_parse));
 	parse_args(argc, argv, &em_conf_parse, &appl_conf_parse);
 

--- a/programs/example/add-ons/Makefile.am
+++ b/programs/example/add-ons/Makefile.am
@@ -1,12 +1,15 @@
 include $(top_srcdir)/programs/Makefile.inc
 
-noinst_PROGRAMS = timer_hello timer_test
+noinst_PROGRAMS = timer_hello timer_test timer_test_periodic
 
 timer_hello_LDFLAGS = $(AM_LDFLAGS) -static
 timer_test_LDFLAGS = $(AM_LDFLAGS) -static
+timer_test_periodic_LDFLAGS = $(AM_LDFLAGS) -static -lm
 
 timer_hello_CFLAGS = $(AM_CFLAGS)
 timer_test_CFLAGS = $(AM_CFLAGS)
+timer_test_periodic_CFLAGS = $(AM_CFLAGS)
 
 dist_timer_hello_SOURCES = timer_hello.c
 dist_timer_test_SOURCES = timer_test.c
+dist_timer_test_periodic_SOURCES = timer_test_periodic.c

--- a/programs/example/add-ons/timer_hello.c
+++ b/programs/example/add-ons/timer_hello.c
@@ -425,6 +425,7 @@ static void app_eo_receive(app_eo_ctx_t *eo_ctx, em_event_t event,
 			   void *q_ctx)
 {
 	int reuse = 0;
+	em_status_t ret;
 
 	(void)queue;
 	(void)q_ctx;
@@ -447,7 +448,10 @@ static void app_eo_receive(app_eo_ctx_t *eo_ctx, em_event_t event,
 			APPL_PRINT((msgin->count & 1) ? "tick\n" : "tock\n");
 
 			/* ack periodic timeout, re-use the same event */
-			em_tmo_ack(msgin->tmo, event);
+			ret = em_tmo_ack(msgin->tmo, event);
+			test_fatal_if(ret != EM_OK,
+				      "em_tmo_ack():%" PRI_STAT, ret);
+
 			reuse = 1; /* do not free this event */
 
 			/* get random timeouts going after 10th message */

--- a/programs/example/add-ons/timer_test_periodic.c
+++ b/programs/example/add-ons/timer_test_periodic.c
@@ -1,0 +1,1739 @@
+/*
+ *   Copyright (c) 2020, Nokia Solutions and Networks
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *
+ * Event Machine timer test for periodic timeouts.
+ *
+ * see instructions - string at timer_test_periodic.h.
+ *
+ * Exception/error management is simplified and aborts on any error.
+ */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <limits.h>
+#include <math.h>
+#include <unistd.h>
+
+#include <event_machine.h>
+#include <event_machine/add-ons/event_machine_timer.h>
+#include <event_machine/platform/env/environment.h>
+#include <odp.h>
+
+#include "cm_setup.h"
+#include "cm_error_handler.h"
+
+#include "timer_test_periodic.h"
+
+#define VERSION "WIP v0.2"
+struct {
+	int num_periodic;
+	uint64_t res_ns;
+	uint64_t period_ns;
+	uint64_t max_period_ns;
+	uint64_t min_period_ns;
+	uint64_t min_work_ns;
+	uint64_t max_work_ns;
+	unsigned int work_prop;
+	int clock_src;
+	const char *csv;
+	int num_runs;
+	int tracebuf;
+	int stoplim;
+	int noskip;
+	int profile;
+	int dispatch;
+	int jobs;
+	long cpucycles;
+	int bg_events;
+	uint64_t bg_time_ns;
+	int bg_size;
+	int bg_chunk;
+
+} g_options = { .num_periodic =  1,	/* defaults for basic check */
+		.res_ns =        10000000ULL,
+		.period_ns =     100000000ULL,
+		.max_period_ns = 0,
+		.min_period_ns = 0,
+		.min_work_ns = 0,
+		.max_work_ns = 0,
+		.work_prop = 0,
+		.clock_src =     EM_TIMER_CLKSRC_DEFAULT,
+		.csv =		 NULL,
+		.num_runs =	 1,
+		.tracebuf =	 DEF_TMO_DATA,
+		.stoplim =	 ((STOP_THRESHOLD * DEF_TMO_DATA) / 100),
+		.noskip =	 0,
+		.profile =	 0,
+		.dispatch =	 0,
+		.jobs =          0,
+		.cpucycles =	 0,
+		.bg_events =     0,
+		.bg_time_ns =	 2000,
+		.bg_size =       1000 * 1024,
+		.bg_chunk =      20 * 1024};
+
+typedef struct app_eo_ctx_t {
+	e_state state;
+	em_tmo_t heartbeat_tmo;
+	em_timer_t test_tmr;
+	em_queue_t hb_q;
+	em_queue_t test_q;
+	em_queue_t bg_q;
+	int cooloff;
+	int last_hbcount;
+	uint64_t hb_hz;
+	uint64_t test_hz;
+	uint64_t time_hz;
+	uint64_t meas_test_hz;
+	uint64_t meas_time_hz;
+	uint64_t linux_hz;
+	uint64_t max_period;
+	time_stamp started;
+	time_stamp stopped;
+	void *bg_data;
+	tmo_setup *tmo_data;
+	core_data cdat[MAX_CORES];
+} app_eo_ctx_t;
+
+typedef struct timer_app_shm_t {
+	em_pool_t pool;
+	app_eo_ctx_t eo_context;
+	em_timer_t hb_tmr;
+	em_timer_t test_tmr;
+} timer_app_shm_t;
+
+#if defined(__aarch64__)
+static inline uint64_t get_cpu_cycle(void)
+{
+	uint64_t r;
+
+	__asm__ volatile ("mrs %0, pmccntr_el0" : "=r"(r) :: "memory");
+	return r;
+}
+#elif defined(__x86_64__)
+static inline uint64_t get_cpu_cycle(void)
+{
+	uint32_t a, d;
+
+	__asm__ volatile ("rdtsc" : "=a"(a), "=d"(d) :: "memory");
+	return (uint64_t)a | ((uint64_t)d) << 32;
+}
+#else
+#error "Code supports Aarch64 or x86_64"
+#endif
+
+/* EM-thread locals */
+static __thread timer_app_shm_t *m_shm;
+
+static void start_periodic(app_eo_ctx_t *eo_context);
+static int handle_periodic(app_eo_ctx_t *eo_context, em_event_t event);
+static void send_stop(app_eo_ctx_t *eo_context);
+static void handle_heartbeat(app_eo_ctx_t *eo_context, em_event_t event);
+static void usage(void);
+static int parse_my_args(int first, int argc, char *argv[]);
+static void analyze(app_eo_ctx_t *eo_ctx);
+static void write_trace(app_eo_ctx_t *eo_ctx, const char *name);
+static void cleanup(app_eo_ctx_t *eo_ctx);
+static int add_trace(app_eo_ctx_t *eo_ctx, int id, e_op op, uint64_t ns,
+		     int count);
+static uint64_t linux_time_ns(void);
+static em_status_t app_eo_start(void *eo_context, em_eo_t eo,
+				const em_eo_conf_t *conf);
+static em_status_t app_eo_start_local(void *eo_context, em_eo_t eo);
+static em_status_t app_eo_stop(void *eo_context, em_eo_t eo);
+static em_status_t app_eo_stop_local(void *eo_context, em_eo_t eo);
+static void app_eo_receive(void *eo_context, em_event_t event,
+			   em_event_type_t type, em_queue_t queue,
+			   void *q_context);
+static time_stamp get_time(void);
+static uint64_t time_to_ns(time_stamp t);
+static time_stamp time_diff(time_stamp t2, time_stamp t1);
+static time_stamp time_sum(time_stamp t1, time_stamp t2);
+static void profile_statistics(e_op op, int cores, app_eo_ctx_t *eo_ctx);
+static void profile_all_stats(int cores, app_eo_ctx_t *eo_ctx);
+static void analyze_measure(app_eo_ctx_t *eo_ctx, uint64_t linuxns,
+			    uint64_t tmrtick, time_stamp timetick);
+static void timing_statistics(app_eo_ctx_t *eo_ctx);
+static void add_prof(app_eo_ctx_t *eo_ctx, time_stamp t1,
+		     e_op op, app_msg_t *msg);
+static int do_one_tmo(int id, app_eo_ctx_t *eo_ctx,
+		      time_stamp *min, time_stamp *max, time_stamp *first);
+static tmo_trace *find_tmo(app_eo_ctx_t *eo_ctx, int id, int count);
+static uint64_t random_tmo(void);
+static uint64_t random_work_ns(rnd_state_t *rng);
+static void enter_cb(em_eo_t eo, void **eo_ctx, em_event_t events[], int num,
+		     em_queue_t *queue, void **q_ctx);
+static void exit_cb(em_eo_t eo);
+static void send_bg_events(app_eo_ctx_t *eo_ctx);
+static int do_bg_work(em_event_t evt, app_eo_ctx_t *eo_ctx);
+static em_status_t my_error_handler(em_eo_t eo, em_status_t error,
+				    em_escope_t escope, va_list args);
+
+/* --------------------------------------- */
+em_status_t my_error_handler(em_eo_t eo, em_status_t error,
+			     em_escope_t escope, va_list args)
+{
+	/* todo improve printout */
+	if (escope == 0xDEAD) { /* test_fatal_if */
+		char *file = va_arg(args, char*);
+		const char *func = va_arg(args, const char*);
+		const int line = va_arg(args, const int);
+		const char *format = va_arg(args, const char*);
+		const char *base = basename(file);
+
+		#pragma GCC diagnostic push
+		#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+			fprintf(stderr, "FATAL - %s:%d, %s():\n",
+				base, line, func);
+			vfprintf(stderr, format, args);
+		#pragma GCC diagnostic pop
+	}
+	return test_error_handler(eo, error, escope, args);
+}
+
+void enter_cb(em_eo_t eo, void **eo_ctx, em_event_t events[], int num,
+	      em_queue_t *queue, void **q_ctx)
+{
+	static int count;
+	app_eo_ctx_t *const my_eo_ctx = *eo_ctx;
+
+	(void)eo;
+	(void)queue;
+	(void)q_ctx;
+
+	if (!my_eo_ctx)
+		return;
+
+	if (g_options.dispatch) {
+		for (int i = 0; i < num; i++) {
+			app_msg_t *msg = em_event_pointer(events[i]);
+
+			add_trace(my_eo_ctx, msg->id, OP_PROF_ENTER_CB,
+				  0, count++);
+		}
+	}
+
+	my_eo_ctx->cdat[em_core_id()].enter = get_time();
+}
+
+void exit_cb(em_eo_t eo)
+{
+	static int count;
+	app_eo_ctx_t *const my_eo_ctx = em_eo_get_context(eo);
+
+	if (!my_eo_ctx)
+		return;
+
+	if (g_options.dispatch)
+		add_trace(my_eo_ctx, -1, OP_PROF_EXIT_CB, 0, count++);
+
+	core_data *cdat = &my_eo_ctx->cdat[em_core_id()];
+	time_stamp took;
+
+	if (__atomic_load_n(&my_eo_ctx->state, __ATOMIC_ACQUIRE) == STATE_RUN) {
+		took = time_diff(get_time(), cdat->enter);
+		cdat->acc_time = time_sum(cdat->acc_time, took);
+	}
+}
+
+inline time_stamp get_time(void)
+{
+	time_stamp t;
+
+	if (g_options.cpucycles)
+		t.u64 = get_cpu_cycle();
+	else
+		t.odp = odp_time_global();
+	return t;
+}
+
+uint64_t time_to_ns(time_stamp t)
+{
+	double ns;
+
+	if (g_options.cpucycles) {
+		double hz = (double)m_shm->eo_context.time_hz;
+
+		ns = (1000000000.0 / hz) * (double)t.u64;
+	} else {
+		ns = (double)odp_time_to_ns(t.odp);
+	}
+	return round(ns);
+}
+
+time_stamp time_diff(time_stamp t2, time_stamp t1)
+{
+	time_stamp t;
+
+	if (g_options.cpucycles)
+		t.u64 = t2.u64 - t1.u64;
+	else
+		t.odp = odp_time_diff(t2.odp, t1.odp);
+
+	return t;
+}
+
+time_stamp time_sum(time_stamp t1, time_stamp t2)
+{
+	time_stamp t;
+
+	if (g_options.cpucycles)
+		t.u64 = t1.u64 + t2.u64;
+	else
+		t.odp = odp_time_sum(t1.odp, t2.odp);
+	return t;
+}
+
+uint64_t linux_time_ns(void)
+{
+	struct timespec ts;
+	uint64_t ns;
+
+	clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+	ns = ts.tv_nsec + (ts.tv_sec * 1000000000ULL);
+	return ns;
+}
+
+void send_stop(app_eo_ctx_t *eo_ctx)
+{
+	em_status_t ret;
+	em_event_t event = em_alloc(sizeof(app_msg_t), EM_EVENT_TYPE_SW,
+				    m_shm->pool);
+
+	test_fatal_if(event == EM_EVENT_UNDEF, "Can't allocate stop event!\n");
+
+	app_msg_t *msg = em_event_pointer(event);
+
+	msg->command = CMD_DONE;
+	msg->id = em_core_id();
+
+	ret = em_send(event, eo_ctx->hb_q);
+	test_fatal_if(ret != EM_OK, "em_send():%" PRI_STAT, ret);
+}
+
+void cleanup(app_eo_ctx_t *eo_ctx)
+{
+	time_stamp tz = {0};
+	int cores = em_core_count();
+
+	for (int i = 0; i < cores; i++) {
+		eo_ctx->cdat[i].count = 0;
+		eo_ctx->cdat[i].cancelled = 0;
+		eo_ctx->cdat[i].jobs_deleted = 0;
+		eo_ctx->cdat[i].jobs = 0;
+		eo_ctx->cdat[i].acc_time = tz;
+	}
+
+	/* TODO the rest? */
+}
+
+void write_trace(app_eo_ctx_t *eo_ctx, const char *name)
+{
+	int cores = em_core_count();
+	FILE *fle = stdout;
+
+	if (strcmp(name, "stdout"))
+		fle = fopen(g_options.csv, "w");
+	if (fle == NULL) {
+		APPL_PRINT("FAILED to open trace file\n");
+		return;
+	}
+
+	fprintf(fle, "\n\n#BEGIN TRACE FORMAT 1\n");
+	fprintf(fle, "resol,period,max_period,clksrc,num_tmo,loops,");
+	fprintf(fle, "traces,noskip,SW-ver\n");
+	fprintf(fle, "%lu,%lu,%lu,%d,%d,%d,%d,%d,%s\n",
+		g_options.res_ns,
+		g_options.period_ns,
+		g_options.max_period_ns,
+		g_options.clock_src,
+		g_options.num_periodic,
+		g_options.num_runs,
+		g_options.tracebuf,
+		g_options.noskip,
+		VERSION);
+	fprintf(fle, "time_hz,meas_time_hz,timer_hz,meas_timer_hz,linux_hz\n");
+	fprintf(fle, "%lu,%lu,%lu,%lu,%lu\n",
+		eo_ctx->time_hz,
+		eo_ctx->meas_time_hz,
+		eo_ctx->test_hz,
+		eo_ctx->meas_test_hz,
+		eo_ctx->linux_hz);
+
+	fprintf(fle, "tmo_id,period_ns,period_ticks,ack_late");
+	fprintf(fle, ",start_tick,start_ns\n");
+	for (int i = 0; i < g_options.num_periodic; i++) {
+		if (USE_TIMER_STAT)
+			fprintf(fle, "%d,%lu,%lu,%lu,%lu,%lu\n",
+				i, eo_ctx->tmo_data[i].period_ns,
+				eo_ctx->tmo_data[i].ticks,
+				eo_ctx->tmo_data[i].ack_late,
+				eo_ctx->tmo_data[i].start,
+				time_to_ns(eo_ctx->tmo_data[i].start_ts));
+		else
+			fprintf(fle, "%d,%lu,%lu,%s,%lu,%lu\n",
+				i, eo_ctx->tmo_data[i].period_ns,
+				eo_ctx->tmo_data[i].ticks,
+				"",
+				eo_ctx->tmo_data[i].start,
+				time_to_ns(eo_ctx->tmo_data[i].start_ts));
+	}
+
+	fprintf(fle, "id,op,tick,time_ns,linux_time_ns,counter,core\n");
+	for (int c = 0; c < cores; c++) {
+		for (int i = 0; i < eo_ctx->cdat[c].count; i++) {
+			uint64_t ns;
+
+			if (eo_ctx->cdat[c].trc[i].op >= OP_PROF_ACK) {
+				/* it's tick diff */
+				ns = time_to_ns(eo_ctx->cdat[c].trc[i].linuxt);
+			} else { /* it's ns from linux */
+				ns = eo_ctx->cdat[c].trc[i].linuxt.u64;
+			}
+
+			fprintf(fle, "%d,%s,%lu,%lu,%lu,%d,%d\n",
+				eo_ctx->cdat[c].trc[i].id,
+				op_labels[eo_ctx->cdat[c].trc[i].op],
+				eo_ctx->cdat[c].trc[i].tick,
+				time_to_ns(eo_ctx->cdat[c].trc[i].ts),
+				ns,
+				eo_ctx->cdat[c].trc[i].count,
+				c);
+		}
+	}
+	fprintf(fle, "#END TRACE\n\n");
+	if (fle != stdout)
+		fclose(fle);
+}
+
+uint64_t random_tmo(void)
+{
+	uint64_t r;
+
+	r = random() % (g_options.max_period_ns - g_options.min_period_ns + 1);
+	return r + g_options.min_period_ns;
+}
+
+uint64_t random_work_ns(rnd_state_t *rng)
+{
+	uint64_t r;
+	int32_t r1;
+
+	random_r(&rng->rdata, &r1);
+	r = (uint64_t)r1;
+	if (r % 100 >= g_options.work_prop) /* propability of work roughly */
+		return 0;
+
+	random_r(&rng->rdata, &r1);
+	r = (uint64_t)r1 % (g_options.max_work_ns - g_options.min_work_ns + 1);
+	return r + g_options.min_work_ns;
+}
+
+tmo_trace *find_tmo(app_eo_ctx_t *eo_ctx, int id, int count)
+{
+	int cores = em_core_count();
+
+	for (int c = 0; c < cores; c++) {
+		for (int i = 0; i < g_options.tracebuf; i++) { /* find id */
+			if (eo_ctx->cdat[c].trc[i].op == OP_TMO &&
+			    eo_ctx->cdat[c].trc[i].id == id &&
+			    eo_ctx->cdat[c].trc[i].count == count) {
+				return &eo_ctx->cdat[c].trc[i];
+			}
+		}
+	}
+	return NULL;
+}
+
+int do_one_tmo(int id, app_eo_ctx_t *eo_ctx,
+	       time_stamp *min, time_stamp *max, time_stamp *first)
+{
+	int num = 0;
+	time_stamp diff;
+	time_stamp prev = {0};
+	int last = 0;
+
+	max->u64 = 0;
+	min->u64 = UINT64_MAX;
+
+	/* find in sequential order for diff */
+	for (int count = 1; count < g_options.tracebuf; count++) {
+		tmo_trace *tmo = find_tmo(eo_ctx, id, count);
+
+		if (!tmo) {
+			if (last != count - 1)
+				APPL_PRINT("MISSING TMO: id %d, count %d\n",
+					   id, count);
+			return num;
+		}
+		last++;
+		if (!num) { /* skip first for min/max */
+			diff = time_diff(tmo->ts,
+					 eo_ctx->tmo_data[id].start_ts);
+			*first = diff;
+			prev = tmo->ts;
+			num++;
+			continue;
+		}
+		diff = time_diff(tmo->ts, prev);
+		if (diff.u64 > max->u64)
+			*max = diff;
+		if (diff.u64 < min->u64)
+			*min = diff;
+		prev = tmo->ts;
+		num++;
+	}
+	return num;
+}
+
+void timing_statistics(app_eo_ctx_t *eo_ctx)
+{
+	time_stamp max_ts = {0}, min_ts = {0}, first_ts = {0};
+	const int cores = em_core_count();
+	uint64_t system_used = time_to_ns(time_diff(eo_ctx->stopped,
+						    eo_ctx->started));
+
+	for (int c = 0; c < cores; c++) {
+		core_data *cdat = &eo_ctx->cdat[c];
+		uint64_t eo_used = time_to_ns(cdat->acc_time);
+		double perc = (double)eo_used / (double)system_used * 100;
+
+		APPL_PRINT("STAT_CORE [%d]: %d tmos, %d jobs, EO used %.1f%% CPU time\n",
+			   c, cdat->count, cdat->jobs, perc);
+	}
+
+	for (int id = 0; id < g_options.num_periodic; id++) { /* each timeout */
+		tmo_setup *tmo_data = &eo_ctx->tmo_data[id];
+		int num = do_one_tmo(id, eo_ctx, &min_ts, &max_ts, &first_ts);
+
+		APPL_PRINT("STAT-TMO [%d]: %d tmos, period %luns (",
+			   id, num, tmo_data->period_ns);
+		if (num > 1)
+			APPL_PRINT("%lu ticks), interval %ldns ... %ldns\n",
+				   tmo_data->ticks,
+				   (int64_t)time_to_ns(min_ts) - (int64_t)tmo_data->period_ns,
+				   (int64_t)time_to_ns(max_ts) - (int64_t)tmo_data->period_ns);
+		else
+			APPL_PRINT("%lu ticks), 1st period %lu\n",
+				   tmo_data->ticks, time_to_ns(first_ts));
+		if (num == 0)
+			APPL_PRINT("	ERROR - no timeouts received\n");
+	}
+
+	if (!g_options.dispatch)
+		return;
+
+	/*
+	 * g_options.dispatch set
+	 *
+	 * Calculate EO rcv min-max-avg:
+	 */
+	uint64_t min = UINT64_MAX, max = 0, avg = 0;
+	time_stamp prev_ts = { 0 };
+	int prev_count = 0;
+	int num = 0;
+
+	for (int c = 0; c < cores; c++) {
+		for (int i = 0; i < g_options.tracebuf; i++) {
+			core_data *cdat = &eo_ctx->cdat[c];
+
+			if (cdat->trc[i].op == OP_PROF_ENTER_CB) {
+				prev_ts = cdat->trc[i].ts;
+				prev_count = cdat->trc[i].count;
+			} else if (cdat->trc[i].op == OP_PROF_EXIT_CB) {
+				time_stamp diff_ts;
+				uint64_t ns;
+
+				if (prev_count != cdat->trc[i].count)
+					APPL_PRINT("No enter cnt=%d\n",
+						   prev_count);
+
+				diff_ts = time_diff(cdat->trc[i].ts, prev_ts);
+				ns = time_to_ns(diff_ts);
+
+				if (ns < min)
+					min = ns;
+				if (ns > max)
+					max = ns;
+
+				avg += ns;
+				num++;
+			}
+		}
+	}
+
+	APPL_PRINT("%d dispatcher enter-exits\n", num);
+	APPL_PRINT("PROF-DISPATCH rcv time: min %luns, max %luns, avg %luns\n",
+		   min, max, num > 0 ? avg / num : 0);
+}
+
+void profile_statistics(e_op op, int cores, app_eo_ctx_t *eo_ctx)
+{
+	uint64_t min = UINT64_MAX;
+	uint64_t max = 0, avg = 0, num = 0;
+	uint64_t t;
+
+	for (int c = 0; c < cores; c++) {
+		for (int i = 0; i < g_options.tracebuf; i++) {
+			if (eo_ctx->cdat[c].trc[i].op == op) {
+				t = time_to_ns(eo_ctx->cdat[c].trc[i].linuxt);
+				if (min > t)
+					min = t;
+				if (max < t)
+					max = t;
+				avg += t;
+				num++;
+			}
+		}
+	}
+	if (num)
+		APPL_PRINT("%s: %lu samples: min %luns, max %luns, avg %luns\n",
+			   op_labels[op], num, min, max, avg / num);
+}
+
+void profile_all_stats(int cores, app_eo_ctx_t *eo_ctx)
+{
+	APPL_PRINT("API profile statistics:\n");
+	profile_statistics(OP_PROF_CREATE, cores, eo_ctx);
+	profile_statistics(OP_PROF_SET, cores, eo_ctx);
+	profile_statistics(OP_PROF_ACK, cores, eo_ctx);
+	profile_statistics(OP_PROF_DELETE, cores, eo_ctx);
+}
+
+void analyze(app_eo_ctx_t *eo_ctx)
+{
+	int cores = em_core_count();
+	int cancelled = 0;
+	int job_del = 0;
+
+	/* checks TODO */
+
+	timing_statistics(eo_ctx);
+
+	if (g_options.profile)
+		profile_all_stats(cores, eo_ctx);
+
+	for (int c = 0; c < cores; c++) {
+		cancelled += eo_ctx->cdat[c].cancelled;
+		job_del += eo_ctx->cdat[c].jobs_deleted;
+	}
+
+	/* write trace file */
+	if (g_options.csv != NULL)
+		write_trace(eo_ctx, g_options.csv);
+
+	APPL_PRINT("%d/%d timeouts were cancelled\n",
+		   cancelled, g_options.num_periodic);
+	if (g_options.bg_events)
+		APPL_PRINT("%d/%d bg jobs were deleted\n",
+			   job_del, g_options.bg_events);
+}
+
+int add_trace(app_eo_ctx_t *eo_ctx, int id, e_op op, uint64_t ns, int count)
+{
+	int core = em_core_id();
+	tmo_trace *tmo = &eo_ctx->cdat[core].trc[eo_ctx->cdat[core].count];
+
+	if (eo_ctx->cdat[core].count < g_options.tracebuf) {
+		if (op < OP_PROF_ACK) /* to be a bit faster for profiling */
+			tmo->tick = em_timer_current_tick(eo_ctx->test_tmr);
+		tmo->op = op;
+		tmo->id = id;
+		tmo->ts = get_time();
+		tmo->linuxt.u64 = ns;
+		tmo->count = count;
+		eo_ctx->cdat[core].count++;
+	}
+	if (eo_ctx->cdat[core].count >= g_options.stoplim)
+		return 0;
+	else
+		return 1;
+}
+
+void send_bg_events(app_eo_ctx_t *eo_ctx)
+{
+	for (int n = 0; n < g_options.bg_events; n++) {
+		em_event_t event = em_alloc(sizeof(app_msg_t),
+					    EM_EVENT_TYPE_SW, m_shm->pool);
+		test_fatal_if(event == EM_EVENT_UNDEF,
+			      "Can't allocate bg event!\n");
+		app_msg_t *msg = em_event_pointer(event);
+
+		msg->command = CMD_BGWORK;
+		msg->count = 0;
+		msg->id = -1;
+		msg->arg = g_options.bg_time_ns;
+		test_fatal_if(em_send(event, eo_ctx->bg_q) != EM_OK,
+			      "Can't allocate bg event!\n");
+	}
+}
+
+void start_periodic(app_eo_ctx_t *eo_ctx)
+{
+	app_msg_t *msg;
+	em_event_t event;
+	em_tmo_t tmo;
+	uint64_t max_period = 0;
+	em_tmo_flag_t flag = EM_TMO_FLAG_PERIODIC;
+	time_stamp t1 = {0};
+
+	if (g_options.noskip)
+		flag |= EM_TMO_FLAG_NOSKIP;
+	eo_ctx->started = get_time();
+
+	for (int i = 0; i < g_options.num_periodic; i++) {
+		event = em_alloc(sizeof(app_msg_t),
+				 EM_EVENT_TYPE_SW, m_shm->pool);
+		test_fatal_if(event == EM_EVENT_UNDEF,
+			      "Can't allocate test event (%ldB)!\n",
+			      sizeof(app_msg_t));
+
+		msg = em_event_pointer(event);
+		msg->command = CMD_TMO;
+		msg->count = 0;
+		msg->id = i;
+		if (g_options.profile)
+			t1 = get_time();
+		tmo = em_tmo_create(m_shm->test_tmr, flag, eo_ctx->test_q);
+		if (g_options.profile)
+			add_prof(eo_ctx, t1, OP_PROF_CREATE, msg);
+
+		test_fatal_if(tmo == EM_TMO_UNDEF,
+			      "Can't allocate test_tmo!\n");
+		msg->tmo = tmo;
+
+		double ns = 1000000000 / (double)eo_ctx->test_hz;
+		uint64_t period;
+
+		if (g_options.period_ns) {
+			period = round((double)g_options.period_ns / ns);
+			if (max_period < g_options.period_ns)
+				max_period = g_options.period_ns;
+			eo_ctx->tmo_data[i].period_ns = g_options.period_ns;
+		} else { /* use random */
+			eo_ctx->tmo_data[i].period_ns = random_tmo();
+			period = round((double)eo_ctx->tmo_data[i].period_ns /
+				       ns);
+			if (max_period < eo_ctx->tmo_data[i].period_ns)
+				max_period = eo_ctx->tmo_data[i].period_ns;
+		}
+		if (EXTRA_PRINTS && i == 0) {
+			APPL_PRINT("Timer Hz %lu ", eo_ctx->test_hz);
+			APPL_PRINT("= Period ns: %f => period %lu ticks\n",
+				   ns, period);
+		}
+
+		test_fatal_if(period < 1, "timer resolution is too low!\n");
+
+		eo_ctx->tmo_data[i].start_ts = get_time();
+		/* replace with abs tick when EM API has start time */
+		eo_ctx->tmo_data[i].start =
+			em_timer_current_tick(m_shm->test_tmr);
+		if (g_options.profile)
+			t1 = get_time();
+		em_status_t stat = em_tmo_set_rel(tmo, period, event);
+
+		if (g_options.profile)
+			add_prof(eo_ctx, t1, OP_PROF_SET, msg);
+
+		test_fatal_if(stat != EM_OK, "Can't activate test tmo!\n");
+
+		eo_ctx->tmo_data[i].ack_late = 0;
+		eo_ctx->tmo_data[i].ticks = period;
+		eo_ctx->max_period = max_period;
+		eo_ctx->cooloff = max_period / 1000000000ULL * 2;
+		if (eo_ctx->cooloff < 4)
+			eo_ctx->cooloff = 4; /* HB periods (sec) */
+	}
+}
+
+void add_prof(app_eo_ctx_t *eo_ctx, time_stamp t1, e_op op, app_msg_t *msg)
+{
+	time_stamp t2, dif;
+
+	t2 = get_time();
+	dif = time_diff(t2, t1);
+	add_trace(eo_ctx, msg->id, op, dif.u64, msg->count);
+	/* if this filled the buffer it's handled on next tmo */
+}
+
+int handle_periodic(app_eo_ctx_t *eo_ctx, em_event_t event)
+{
+	int core = em_core_id();
+	app_msg_t *msg = (app_msg_t *)em_event_pointer(event);
+	int reuse = 1;
+	e_state state = __atomic_load_n(&eo_ctx->state, __ATOMIC_ACQUIRE);
+	time_stamp t1 = {0};
+
+	msg->count++;
+	if (likely(state == STATE_RUN)) {
+		if (!add_trace(eo_ctx, msg->id, OP_TMO, 0, msg->count))
+			send_stop(eo_ctx);
+
+		if (g_options.work_prop) {
+			uint64_t work = random_work_ns(&eo_ctx->cdat[core].rng);
+
+			if (work) {
+				time_stamp now, t2;
+				uint64_t ns;
+
+				now = get_time();
+				ns = time_to_ns(now);
+				do {
+					t2 = get_time();
+				} while (time_to_ns(t2) < (ns + work));
+				add_trace(eo_ctx, msg->id, OP_WORK,
+					  work, msg->count);
+			}
+		}
+	} else if (state == STATE_COOLOFF) { /* trace, but cancel */
+		em_event_t tmo_event = EM_EVENT_UNDEF;
+
+		add_trace(eo_ctx, msg->id, OP_TMO,
+			  0, msg->count);
+
+		#if (USE_TIMER_STAT)
+		const em_timer_tmo_stat_t *stat = em_tmo_get_pstat(msg->tmo);
+
+		APPL_PRINT("STAT-ACK [%d]:  %lu acks, %lu late, %lu err\n",
+			   msg->id, stat->acks, stat->late, stat->error);
+		eo_ctx->tmo_data[msg->id].ack_late = stat->late;
+		#endif
+		if (g_options.profile)
+			t1 = get_time();
+		em_tmo_delete(msg->tmo, &tmo_event);
+		if (g_options.profile)
+			add_prof(eo_ctx, t1, OP_PROF_DELETE, msg);
+
+		eo_ctx->cdat[core].cancelled++;
+		if (tmo_event != EM_EVENT_UNDEF)
+			em_free(tmo_event);
+
+		add_trace(eo_ctx, msg->id, OP_CANCEL,
+			  0, msg->count);
+		return 1;
+	}
+
+	add_trace(eo_ctx, msg->id, OP_ACK, 0, msg->count);
+
+	if (g_options.profile)
+		t1 = get_time();
+	if (em_tmo_ack(msg->tmo, event) != EM_OK)
+		test_error(EM_ERROR_SET_FATAL(0xDEAD), 0xBEEF, "ack() fail!\n");
+	if (g_options.profile)
+		add_prof(eo_ctx, t1, OP_PROF_ACK, msg);
+
+	return reuse;
+}
+
+void analyze_measure(app_eo_ctx_t *eo_ctx, uint64_t linuxns, uint64_t tmrtick,
+		     time_stamp timetick)
+{
+	uint64_t linux_t2 = linux_time_ns();
+	time_stamp time_t2 = get_time();
+	uint64_t tmr_t2 = em_timer_current_tick(eo_ctx->test_tmr);
+
+	linux_t2 = linux_t2 - linuxns;
+	time_t2 = time_diff(time_t2, timetick);
+	tmr_t2 = tmr_t2 - tmrtick;
+	APPL_PRINT("%lu timer ticks in %luns (linux time) ", tmr_t2, linux_t2);
+	double hz = 1000000000 /
+		    ((double)linux_t2 / (double)tmr_t2);
+	APPL_PRINT("=> %.1fHz (%.1fMHz). Timer reports %luHz\n",
+		   hz, hz / 1000000, eo_ctx->test_hz);
+	eo_ctx->meas_test_hz = round(hz);
+	hz = 1000000000 / ((double)linux_t2 / (double)time_t2.u64);
+	APPL_PRINT("Timestamp measured: %.1fHz (%.1fMHz)\n",
+		   hz, hz / 1000000);
+	eo_ctx->meas_time_hz = round(hz);
+
+	if (g_options.cpucycles == 1) /* use measured */
+		eo_ctx->time_hz = eo_ctx->meas_time_hz;
+	if (g_options.cpucycles > 1) /* freq given */
+		eo_ctx->time_hz = (uint64_t)g_options.cpucycles;
+
+	test_fatal_if(tmr_t2 < 1, "TIMER SEEMS NOT RUNNING AT ALL!?");
+}
+
+int do_bg_work(em_event_t evt, app_eo_ctx_t *eo_ctx)
+{
+	app_msg_t *msg = (app_msg_t *)em_event_pointer(evt);
+	time_stamp t1 = get_time();
+	time_stamp ts;
+	int32_t rnd;
+	int core = em_core_id();
+	uint64_t sum = 0;
+
+	if (__atomic_load_n(&eo_ctx->state, __ATOMIC_ACQUIRE) != STATE_RUN) {
+		eo_ctx->cdat[core].jobs_deleted++;
+		if (EXTRA_PRINTS)
+			APPL_PRINT("Deleting job after %u iterations\n",
+				   msg->count);
+		return 0; /* stop & delete */
+	}
+
+	if (g_options.jobs)
+		add_trace(eo_ctx, -1, OP_BGWORK, msg->arg, msg->count);
+
+	msg->count++;
+	eo_ctx->cdat[core].jobs++;
+	int blocks = g_options.bg_size / g_options.bg_chunk;
+
+	random_r(&eo_ctx->cdat[core].rng.rdata, &rnd);
+	rnd = rnd % blocks;
+	uint64_t *dptr = (uint64_t *)((uintptr_t)eo_ctx->bg_data +
+				      rnd * g_options.bg_chunk);
+	/* printf("%d: %p - %p\n", rnd, eo_ctx->bg_data, dptr); */
+
+	do {
+		/* jump around reading from selected chunk */
+		random_r(&eo_ctx->cdat[core].rng.rdata, &rnd);
+		rnd = rnd % (g_options.bg_chunk / sizeof(uint64_t));
+		/* printf("%d: %p - %p\n", rnd, eo_ctx->bg_data, dptr+rnd); */
+		sum += *(dptr + rnd);
+		ts = time_diff(get_time(), t1);
+	} while (time_to_ns(ts) < msg->arg);
+
+	*dptr = sum;
+	test_fatal_if(em_send(evt, eo_ctx->bg_q) != EM_OK,
+		      "Failed to send BG job event!");
+	return 1;
+}
+
+void handle_heartbeat(app_eo_ctx_t *eo_ctx, em_event_t event)
+{
+	app_msg_t *msg = (app_msg_t *)em_event_pointer(event);
+	int cores = em_core_count();
+	int done = 0;
+	e_state state = __atomic_load_n(&eo_ctx->state, __ATOMIC_SEQ_CST);
+	static int runs;
+	static uint64_t linuxns;
+	static uint64_t tmrtick;
+	static time_stamp timetick;
+
+	/* heartbeat runs states of the test */
+
+	msg->count++;
+	add_trace(eo_ctx, -1, OP_HB,
+		  linux_time_ns(), msg->count);
+
+	if (EXTRA_PRINTS)
+		APPL_PRINT(".");
+
+	switch (state) {
+	case STATE_INIT:
+		if (msg->count > eo_ctx->last_hbcount + INIT_WAIT) {
+			__atomic_fetch_add(&eo_ctx->state, 1, __ATOMIC_SEQ_CST);
+			eo_ctx->last_hbcount = msg->count;
+			APPL_PRINT("Starting tick measurement\n");
+		}
+		break;
+
+	case STATE_MEASURE:	/* measure frequencies */
+		if (linuxns == 0) {
+			linuxns = linux_time_ns();
+			timetick = get_time();
+			tmrtick = em_timer_current_tick(eo_ctx->test_tmr);
+		}
+		if (msg->count > eo_ctx->last_hbcount + MEAS_PERIOD) {
+			analyze_measure(eo_ctx, linuxns, tmrtick, timetick);
+			linuxns = 0;
+			/* start new run */
+			if (g_options.num_runs > 1)
+				APPL_PRINT("** Round %d\n", runs + 1);
+			__atomic_fetch_add(&eo_ctx->state, 1, __ATOMIC_SEQ_CST);
+			add_trace(eo_ctx, -1, OP_STATE,
+				  linux_time_ns(), eo_ctx->state);
+		}
+		break;
+
+	case STATE_STABILIZE:
+		if (g_options.bg_events)
+			send_bg_events(eo_ctx);
+		__atomic_fetch_add(&eo_ctx->state, 1, __ATOMIC_SEQ_CST);
+		add_trace(eo_ctx, -1, OP_STATE,
+			  linux_time_ns(), eo_ctx->state);
+		start_periodic(eo_ctx);
+		eo_ctx->last_hbcount = msg->count;
+		break;
+
+	case STATE_RUN:
+		for (int i = 0; i < cores; i++) {
+			if (eo_ctx->cdat[i].count >=
+			   g_options.tracebuf) {
+				done++;
+				break;
+			}
+		}
+		if (done) {
+			__atomic_fetch_add(&eo_ctx->state, 1,
+					   __ATOMIC_SEQ_CST);
+			add_trace(eo_ctx, -1, OP_STATE, linux_time_ns(),
+				  eo_ctx->state);
+			eo_ctx->last_hbcount = msg->count;
+		}
+		break;
+
+	case STATE_COOLOFF:
+		if (msg->count > (eo_ctx->last_hbcount + eo_ctx->cooloff)) {
+			__atomic_fetch_add(&eo_ctx->state, 1,
+					   __ATOMIC_SEQ_CST);
+			add_trace(eo_ctx, -1, OP_STATE,
+				  linux_time_ns(), eo_ctx->state);
+			eo_ctx->last_hbcount = msg->count;
+		}
+		break;
+
+	case STATE_ANALYZE:
+		APPL_PRINT("\n");
+		analyze(eo_ctx);
+		cleanup(eo_ctx);
+		__atomic_store_n(&eo_ctx->state, STATE_INIT,
+				 __ATOMIC_SEQ_CST);
+		runs++;
+		if (runs >= g_options.num_runs && g_options.num_runs != 0) {
+			/* terminate test app */
+			APPL_PRINT("%d runs done\n", runs);
+			raise(SIGINT);
+		}
+		eo_ctx->last_hbcount = msg->count;
+		break;
+
+	default:
+		test_error(EM_ERROR_SET_FATAL(0xDEAD), 0xBEEF,
+			   "Invalid test state");
+	}
+
+	if (em_tmo_ack(eo_ctx->heartbeat_tmo, event) != EM_OK)
+		test_error(EM_ERROR_SET_FATAL(0xDEAD), 0xBEEF,
+			   "HB ack() fail!\n");
+}
+
+void usage(void)
+{
+	printf("%s\n", instructions);
+
+	printf("Usage:\n");
+	for (int i = 0; ; i++) {
+		if (longopts[i].name == NULL || descopts[i] == NULL)
+			break;
+		printf("--%s or -%c: %s\n", longopts[i].name, longopts[i].val,
+		       descopts[i]);
+	}
+}
+
+int parse_my_args(int first, int argc, char *argv[])
+{
+	optind = first + 1; /* skip '--' */
+	while (1) {
+		int opt;
+		int long_index;
+		char *endptr;
+		long num;
+
+		opt = getopt_long(argc, argv, shortopts,
+				  longopts, &long_index);
+
+		if (opt == -1)
+			break;  /* No more options */
+
+		switch (opt) {
+		case 's': {
+			g_options.noskip = 1;
+		}
+		break;
+		case 'a': {
+			g_options.profile = 1;
+		}
+		break;
+		case 'b': {
+			g_options.jobs = 1;
+		}
+		break;
+		case 'd': {
+			g_options.dispatch = 1;
+		}
+		break;
+		case 'g': {
+			g_options.cpucycles = 1;
+			if (optarg != NULL) {
+				num = strtol(optarg, &endptr, 0);
+				if (*endptr != '\0' || num < 2)
+					return 0;
+				g_options.cpucycles = num;
+			}
+		}
+		break;
+		case 'w': {
+			g_options.csv = "stdout";
+			if (optarg != NULL)
+				g_options.csv = optarg;
+		}
+		break;
+		case 'm': {
+			num = strtol(optarg, &endptr, 0);
+			if (*endptr != '\0' || num < 0)
+				return 0;
+			g_options.max_period_ns = num;
+		}
+		break;
+		case 'l': {
+			num = strtol(optarg, &endptr, 0);
+			if (*endptr != '\0' || num < 1)
+				return 0;
+			g_options.min_period_ns = num;
+		}
+		break;
+		case 't': {
+			unsigned long size, perc;
+
+			num = sscanf(optarg, "%lu,%lu", &size, &perc);
+			if (num == 0 || size < 10 ||
+			    sizeof(tmo_trace) * size > MAX_TMO_BYTES)
+				return 0;
+			g_options.tracebuf = size;
+			if (num == 2 && perc > 100)
+				return 0;
+			if (num == 2)
+				g_options.stoplim = ((perc * size) / 100);
+			else
+				g_options.stoplim =
+					((STOP_THRESHOLD * size) / 100);
+		}
+		break;
+		case 'e': {
+			unsigned int min_us, max_us, prop;
+
+			if (sscanf(optarg, "%u,%u,%u",
+				   &min_us, &max_us, &prop) != 3)
+				return 0;
+			if (prop > 100 || max_us < 1)
+				return 0;
+			g_options.min_work_ns = 1000ULL * min_us;
+			g_options.max_work_ns = 1000ULL * max_us;
+			g_options.work_prop = prop;
+		}
+		break;
+		case 'j': {
+			unsigned int evts, us, kb, chunk;
+
+			num = sscanf(optarg, "%u,%u,%u,%u",
+				     &evts, &us, &kb, &chunk);
+			if (num == 0 || evts < 1)
+				return 0;
+			g_options.bg_events = evts;
+			if (num > 1 && us)
+				g_options.bg_time_ns = us * 1000ULL;
+			if (num > 2 && kb)
+				g_options.bg_size = kb * 1024;
+			if (num > 3 && chunk)
+				g_options.bg_chunk = chunk * 1024;
+			if (g_options.bg_chunk > g_options.bg_size)
+				return 0;
+		}
+		break;
+		case 'n': {
+			num = strtol(optarg, &endptr, 0);
+			if (*endptr != '\0' || num < 1)
+				return 0;
+			g_options.num_periodic = num;
+		}
+		break;
+		case 'p': {
+			num = strtol(optarg, &endptr, 0);
+			if (*endptr != '\0' || num < 0)
+				return 0;
+			g_options.period_ns = num;
+		}
+		break;
+		case 'c': {
+			num = strtol(optarg, &endptr, 0);
+			if (*endptr != '\0' || num < 0)
+				return 0;
+			g_options.clock_src = num;
+		}
+		break;
+		case 'r': {
+			num = strtol(optarg, &endptr, 0);
+			if (*endptr != '\0' || num < 0)
+				return 0;
+			g_options.res_ns = num;
+		}
+		break;
+		case 'x': {
+			num = strtol(optarg, &endptr, 0);
+			if (*endptr != '\0' || num < 0)
+				return 0;
+			g_options.num_runs = num;
+		}
+		break;
+
+		case 'h':
+		default:
+			opterr = 0;
+			usage();
+			return 0;
+		}
+	}
+
+	optind = 1; /* cm_setup() to parse again */
+	return 1;
+}
+
+/**
+ * Before EM - Init of the test application.
+ *
+ * The shared memory is needed if EM instance runs on multiple processes.
+ * Doing it like this makes it possible to run the app both as threads (-t)
+ * as well as processes (-p).
+ *
+ * @attention Run on all cores.
+ *
+ * @see cm_setup() for setup and dispatch.
+ */
+void test_init(void)
+{
+	int core = em_core_id();
+
+	/* first core creates ShMem */
+	if (core == 0) {
+		m_shm = env_shared_reserve("Timer_test",
+					   sizeof(timer_app_shm_t));
+		/* initialize it */
+		if (m_shm)
+			memset(m_shm, 0, sizeof(timer_app_shm_t));
+
+		APPL_PRINT("%ldk shared memory for app context\n",
+			   sizeof(timer_app_shm_t) / 1000);
+
+	} else {
+		m_shm = env_shared_lookup("Timer_test");
+	}
+
+	if (m_shm == NULL) {
+		test_error(EM_ERROR_SET_FATAL(0xDEAD), 0xBEEF,
+			   "ShMem init failed on EM-core: %u",
+			   em_core_id());
+	}
+
+	APPL_PRINT("core %d: %s done\n", core, __func__);
+}
+
+/**
+ * Startup of the timer test EM application.
+ *
+ * At this point EM is up, but no EOs exist. EM API can be used to create
+ * queues, EOs etc.
+ *
+ * @attention Run only on one EM core.
+ *
+ * @param appl_conf Application configuration
+ *
+ * @see cm_setup() for setup and dispatch.
+ */
+void test_start(appl_conf_t *const appl_conf)
+{
+	em_eo_t eo;
+	em_timer_attr_t attr;
+	em_queue_t queue;
+	em_status_t stat;
+	app_eo_ctx_t *eo_ctx;
+
+	if (appl_conf->num_pools >= 1)
+		m_shm->pool = appl_conf->pools[0];
+	else
+		m_shm->pool = EM_POOL_DEFAULT;
+
+	if (g_options.max_period_ns < g_options.period_ns &&
+	    g_options.max_period_ns)
+		g_options.max_period_ns = g_options.period_ns;
+
+	if (g_options.min_period_ns == 0)
+		g_options.min_period_ns = DEF_MIN_PERIOD * g_options.res_ns;
+
+	int64_t diff = (int64_t)g_options.max_period_ns -
+		       (int64_t)g_options.min_period_ns;
+
+	if (diff < 100000) {
+		APPL_PRINT("NOTE: max-min timeout too small, max adjusted\n");
+		g_options.max_period_ns = g_options.min_period_ns + 100000;
+	}
+
+	eo_ctx = &m_shm->eo_context;
+	eo_ctx->tmo_data = calloc(g_options.num_periodic, sizeof(tmo_setup));
+	test_fatal_if(eo_ctx->tmo_data == NULL, "Can't alloc tmo_setups");
+
+	eo = em_eo_create(APP_EO_NAME, app_eo_start, app_eo_start_local,
+			  app_eo_stop, app_eo_stop_local, app_eo_receive,
+			  eo_ctx);
+	test_fatal_if(eo == EM_EO_UNDEF, "Failed to create EO!");
+
+	stat = em_register_error_handler(my_error_handler);
+	test_fatal_if(stat != EM_OK, "Failed to register error handler");
+
+	/* atomic queue for control */
+	queue = em_queue_create("Control Q",
+				EM_QUEUE_TYPE_ATOMIC,
+				EM_QUEUE_PRIO_NORMAL,
+				EM_QUEUE_GROUP_DEFAULT, NULL);
+	stat = em_eo_add_queue_sync(eo, queue);
+	test_fatal_if(stat != EM_OK, "Failed to create queue!");
+	eo_ctx->hb_q = queue;
+
+	/* another parallel high priority for timeout handling*/
+	queue = em_queue_create("Tmo Q",
+				EM_QUEUE_TYPE_PARALLEL,
+				EM_QUEUE_PRIO_HIGHEST,
+				EM_QUEUE_GROUP_DEFAULT, NULL);
+	stat = em_eo_add_queue_sync(eo, queue);
+	test_fatal_if(stat != EM_OK, "Failed to create queue!");
+	eo_ctx->test_q = queue;
+
+	/* another parallel low priority for background work*/
+	queue = em_queue_create("BG Q",
+				EM_QUEUE_TYPE_PARALLEL,
+				EM_QUEUE_PRIO_LOWEST,
+				EM_QUEUE_GROUP_DEFAULT, NULL);
+	stat = em_eo_add_queue_sync(eo, queue);
+	test_fatal_if(stat != EM_OK, "Failed to add queue!");
+	eo_ctx->bg_q = queue;
+
+	/* create two timers so HB and tests can be independent */
+	memset(&attr, 0, sizeof(em_timer_attr_t));
+	strncpy(attr.name, "HBTimer", EM_TIMER_NAME_LEN);
+	attr.resolution = 100ULL * 1000ULL * 1000ULL; /* 100ms */
+	m_shm->hb_tmr = em_timer_create(&attr);
+	test_fatal_if(m_shm->hb_tmr == EM_TIMER_UNDEF,
+		      "Failed to create HB timer!");
+
+	memset(&attr, 0, sizeof(em_timer_attr_t));
+	strncpy(attr.name, "TestTimer", EM_TIMER_NAME_LEN);
+	attr.num_tmo = g_options.num_periodic + 1;
+	attr.resolution = g_options.res_ns;
+	attr.clk_src = (em_timer_clksrc_t)g_options.clock_src;
+	attr.max_tmo = g_options.max_period_ns;
+	m_shm->test_tmr = em_timer_create(&attr);
+	test_fatal_if(m_shm->test_tmr == EM_TIMER_UNDEF,
+		      "Failed to create test timer!");
+	eo_ctx->test_tmr = m_shm->test_tmr;
+
+	/* Start EO */
+	stat = em_eo_start_sync(eo, NULL, NULL);
+	test_fatal_if(stat != EM_OK, "Failed to start EO!");
+}
+
+void
+test_stop(appl_conf_t *const appl_conf)
+{
+	const int core = em_core_id();
+	em_status_t ret;
+	em_eo_t eo;
+
+	(void)appl_conf;
+
+	APPL_PRINT("%s() on EM-core %d\n", __func__, core);
+
+	eo = em_eo_find(APP_EO_NAME);
+	test_fatal_if(eo == EM_EO_UNDEF,
+		      "Could not find EO:%s", APP_EO_NAME);
+
+	ret = em_eo_stop_sync(eo);
+	test_fatal_if(ret != EM_OK,
+		      "EO:%" PRI_EO " stop:%" PRI_STAT "", eo, ret);
+	ret = em_eo_delete(eo);
+	test_fatal_if(ret != EM_OK,
+		      "EO:%" PRI_EO " delete:%" PRI_STAT "", eo, ret);
+
+	ret = em_timer_delete(m_shm->hb_tmr);
+	test_fatal_if(ret != EM_OK,
+		      "Timer:%" PRI_TMR " delete:%" PRI_STAT "",
+		      m_shm->hb_tmr, ret);
+	ret = em_timer_delete(m_shm->test_tmr);
+	test_fatal_if(ret != EM_OK,
+		      "Timer:%" PRI_TMR " delete:%" PRI_STAT "",
+		      m_shm->test_tmr, ret);
+
+	free(m_shm->eo_context.tmo_data);
+}
+
+void
+test_term(void)
+{
+	int core = em_core_id();
+
+	APPL_PRINT("%s() on EM-core %d\n", __func__, core);
+
+	if (m_shm != NULL) {
+		env_shared_free(m_shm);
+		m_shm = NULL;
+		em_unregister_error_handler();
+	}
+}
+
+static em_status_t app_eo_start(void *eo_context, em_eo_t eo,
+				const em_eo_conf_t *conf)
+{
+	#define PRINT_MAX_TMRS 4
+	em_timer_attr_t attr;
+	em_timer_t tmr[PRINT_MAX_TMRS];
+	int num_timers;
+	app_msg_t *msg;
+	struct timespec ts;
+	uint64_t period;
+	em_event_t event;
+	app_eo_ctx_t *eo_ctx = (app_eo_ctx_t *)eo_context;
+
+	(void)eo;
+	(void)conf;
+
+	APPL_PRINT("EO start\n");
+
+	num_timers = em_timer_get_all(tmr, PRINT_MAX_TMRS);
+
+	for (int i = 0;
+	     i < (num_timers > PRINT_MAX_TMRS ? PRINT_MAX_TMRS : num_timers);
+	     i++) {
+		if (em_timer_get_attr(tmr[i], &attr) != EM_OK) {
+			APPL_ERROR("Can't get timer info\n");
+			return EM_ERR_BAD_ID;
+		}
+		APPL_PRINT("Timer \"%s\" info:\n", attr.name);
+		APPL_PRINT("  -resolution: %" PRIu64 " ns\n", attr.resolution);
+		APPL_PRINT("  -max_tmo: %" PRIu64 " ms\n", attr.max_tmo / 1000);
+		APPL_PRINT("  -num_tmo: %d\n", attr.num_tmo);
+		APPL_PRINT("  -clk_src: %d\n", attr.clk_src);
+		APPL_PRINT("  -tick Hz: %" PRIu64 " hz\n",
+			   em_timer_get_freq(tmr[i]));
+	}
+
+	if (g_options.max_period_ns == 0) {
+		em_timer_get_attr(eo_ctx->test_tmr, &attr);
+		g_options.max_period_ns = attr.max_tmo;
+	}
+
+	APPL_PRINT("\nActive run options:\n");
+	APPL_PRINT(" num timers:   %d\n", g_options.num_periodic);
+	APPL_PRINT(" resolution:   %luns (%fs)\n", g_options.res_ns,
+		   (double)g_options.res_ns / 1000000000);
+	APPL_PRINT(" period:       %luns (%fs%s)\n", g_options.period_ns,
+		   (double)g_options.period_ns / 1000000000,
+		   g_options.period_ns == 0 ? " (random)" : "");
+	APPL_PRINT(" max period:   %luns (%fs)\n", g_options.max_period_ns,
+		   (double)g_options.max_period_ns / 1000000000);
+	APPL_PRINT(" min period:   %luns (%fs)\n", g_options.min_period_ns,
+		   (double)g_options.min_period_ns / 1000000000);
+	APPL_PRINT(" csv:          %s\n",
+		   g_options.csv == NULL ? "(no)" : g_options.csv);
+	APPL_PRINT(" tracebuffer:  %d tmo events (%luKiB)\n",
+		   g_options.tracebuf,
+		   g_options.tracebuf * sizeof(tmo_trace) / 1024);
+	APPL_PRINT(" stop limit:   %d tmo events\n", g_options.stoplim);
+	APPL_PRINT(" use NOSKIP:   %s\n", g_options.noskip ? "yes" : "no");
+	APPL_PRINT(" profile API:  %s\n", g_options.profile ? "yes" : "no");
+	APPL_PRINT(" dispatch prof:%s\n", g_options.dispatch ? "yes" : "no");
+	APPL_PRINT(" time stamps:  %s\n", g_options.cpucycles ?
+		   "CPU cycles" : "odp_time()");
+	APPL_PRINT(" work propability:%u%%\n", g_options.work_prop);
+	if (g_options.work_prop) {
+		APPL_PRINT(" min_work:     %luns\n", g_options.min_work_ns);
+		APPL_PRINT(" max_work:     %luns\n", g_options.max_work_ns);
+	}
+	APPL_PRINT(" bg events:    %u\n", g_options.bg_events);
+	eo_ctx->bg_data = NULL;
+	if (g_options.bg_events) {
+		APPL_PRINT(" bg work:      %luus\n",
+			   g_options.bg_time_ns / 1000);
+		APPL_PRINT(" bg data:      %ukiB\n", g_options.bg_size / 1024);
+		APPL_PRINT(" bg chunk:     %ukiB (%u blks)\n",
+			   g_options.bg_chunk / 1024,
+			   g_options.bg_size / g_options.bg_chunk);
+		APPL_PRINT(" bg trace:     %s\n",
+			   g_options.jobs ? "yes" : "no");
+
+		eo_ctx->bg_data = malloc(g_options.bg_size);
+		test_fatal_if(eo_ctx->bg_data == NULL,
+			      "Can't allocate bg work data (%dkiB)!\n",
+			      g_options.bg_size / 1024);
+	}
+
+	APPL_PRINT("\nTracing first %d tmo events\n", g_options.tracebuf);
+
+	/* create periodic timeout for heartbeat */
+	eo_ctx->heartbeat_tmo = em_tmo_create(m_shm->hb_tmr,
+					      EM_TMO_FLAG_PERIODIC,
+					      eo_ctx->hb_q);
+	test_fatal_if(eo_ctx->heartbeat_tmo == EM_TMO_UNDEF,
+		      "Can't allocate heartbeat_tmo!\n");
+
+	event = em_alloc(sizeof(app_msg_t), EM_EVENT_TYPE_SW, m_shm->pool);
+	test_fatal_if(event == EM_EVENT_UNDEF, "Can't allocate event (%ldB)!\n",
+		      sizeof(app_msg_t));
+
+	msg = em_event_pointer(event);
+	msg->command = CMD_HEARTBEAT;
+	msg->count = 0;
+	msg->id = -1;
+	eo_ctx->hb_hz = em_timer_get_freq(m_shm->hb_tmr);
+	if (eo_ctx->hb_hz < 10)
+		APPL_ERROR("WARNING - HB timer hz very low!\n");
+	else
+		APPL_PRINT("HB timer frequency is %lu\n", eo_ctx->hb_hz);
+
+	period = eo_ctx->hb_hz; /* 1s */
+	test_fatal_if(period < 1, "timer resolution is too low!\n");
+
+	/* linux time check */
+	test_fatal_if(clock_getres(CLOCK_MONOTONIC, &ts) != 0,
+		      "clock_getres() failed!\n");
+
+	period = ts.tv_nsec + (ts.tv_sec * 1000000000ULL);
+	eo_ctx->linux_hz = 1000000000ULL / period;
+	APPL_PRINT("Linux reports clock running at %" PRIu64 " hz\n",
+		   eo_ctx->linux_hz);
+
+	APPL_PRINT("ODP says time_global runs at %luHz\n",
+		   odp_time_global_res());
+	if (!g_options.cpucycles)
+		eo_ctx->time_hz = odp_time_global_res();
+
+	/* start heartbeat */
+	__atomic_store_n(&eo_ctx->state, STATE_INIT, __ATOMIC_SEQ_CST);
+
+	em_status_t stat = em_tmo_set_rel(eo_ctx->heartbeat_tmo, eo_ctx->hb_hz,
+					  event);
+
+	test_fatal_if(stat != EM_OK, "Can't activate heartbeat tmo!\n");
+	eo_ctx->test_hz = em_timer_get_freq(m_shm->test_tmr);
+
+	stat = em_dispatch_register_enter_cb(enter_cb);
+	test_fatal_if(stat != EM_OK, "enter_cb() register failed!");
+	stat = em_dispatch_register_exit_cb(exit_cb);
+	test_fatal_if(stat != EM_OK, "exit_cb() register failed!");
+
+	srandom(time(NULL));
+	if (g_options.max_work_ns > RAND_MAX ||
+	    g_options.max_period_ns > RAND_MAX)
+		APPL_PRINT("WARN - rnd number range is less than max values\n");
+	if (EXTRA_PRINTS)
+		APPL_PRINT("WARN - extra prints enabled, expect some jitter\n");
+
+	return EM_OK;
+}
+
+/**
+ * @private
+ *
+ * EO per thread start function.
+ */
+static em_status_t app_eo_start_local(void *eo_context, em_eo_t eo)
+{
+	app_eo_ctx_t *const eo_ctx = eo_context;
+	int core = em_core_id();
+
+	(void)eo;
+
+	APPL_PRINT("EO local start\n");
+	test_fatal_if(core >= MAX_CORES, "Too many cores!");
+	eo_ctx->cdat[core].trc = calloc(g_options.tracebuf, sizeof(tmo_trace));
+	test_fatal_if(eo_ctx->cdat[core].trc == NULL,
+		      "Failed to allocate trace buffer!");
+	eo_ctx->cdat[core].count = 0;
+	eo_ctx->cdat[core].cancelled = 0;
+	eo_ctx->cdat[core].jobs_deleted = 0;
+	eo_ctx->cdat[core].jobs = 0;
+
+	memset(&eo_ctx->cdat[core].rng, 0, sizeof(rnd_state_t));
+	initstate_r(time(NULL), eo_ctx->cdat[core].rng.rndstate, RND_STATE_BUF,
+		    &eo_ctx->cdat[core].rng.rdata);
+	srandom_r(time(NULL), &eo_ctx->cdat[core].rng.rdata);
+	return EM_OK;
+}
+
+/**
+ * @private
+ *
+ * EO stop function.
+ */
+static em_status_t app_eo_stop(void *eo_context, em_eo_t eo)
+{
+	app_eo_ctx_t *const eo_ctx = eo_context;
+	em_event_t event = EM_EVENT_UNDEF;
+	em_status_t ret;
+
+	APPL_PRINT("EO stop\n");
+
+	if (eo_ctx->heartbeat_tmo != EM_TMO_UNDEF) {
+		em_tmo_delete(eo_ctx->heartbeat_tmo, &event);
+		eo_ctx->heartbeat_tmo = EM_TMO_UNDEF;
+		if (event != EM_EVENT_UNDEF)
+			em_free(event);
+	}
+
+	/* TODO cancel all test timers */
+
+	ret = em_eo_remove_queue_all_sync(eo, EM_TRUE);
+	test_fatal_if(ret != EM_OK,
+		      "EO remove queue all:%" PRI_STAT " EO:%" PRI_EO "",
+		      ret, eo);
+
+	ret = em_dispatch_unregister_enter_cb(enter_cb);
+	test_fatal_if(ret != EM_OK, "enter_cb() unregister:%" PRI_STAT, ret);
+	ret = em_dispatch_unregister_exit_cb(exit_cb);
+	test_fatal_if(ret != EM_OK, "exit_cb() unregister:%" PRI_STAT, ret);
+
+	if (eo_ctx->bg_data != NULL)
+		free(eo_ctx->bg_data);
+	eo_ctx->bg_data = NULL;
+	return EM_OK;
+}
+
+/**
+ * @private
+ *
+ * EO stop local function.
+ */
+static em_status_t app_eo_stop_local(void *eo_context, em_eo_t eo)
+{
+	int core = em_core_id();
+	app_eo_ctx_t *const eo_ctx = eo_context;
+
+	(void)eo;
+
+	APPL_PRINT("EO local stop\n");
+
+	free(eo_ctx->cdat[core].trc);
+	eo_ctx->cdat[core].trc = NULL;
+	return EM_OK;
+}
+
+/**
+ * @private
+ *
+ * EO receive function
+ */
+static void app_eo_receive(void *eo_context, em_event_t event,
+			   em_event_type_t type, em_queue_t queue,
+			   void *q_context)
+{
+	app_eo_ctx_t *const eo_ctx = eo_context;
+	int reuse = 0;
+	static int last_count;
+
+	(void)q_context;
+
+	if (type == EM_EVENT_TYPE_SW) {
+		app_msg_t *msgin = (app_msg_t *)em_event_pointer(event);
+
+		switch (msgin->command) {
+		case CMD_TMO:
+			reuse = handle_periodic(eo_ctx, event);
+			break;
+
+		case CMD_HEARTBEAT: /* uses atomic queue */
+			handle_heartbeat(eo_ctx, event);
+			last_count = msgin->count;
+			reuse = 1;
+			break;
+
+		case CMD_BGWORK:
+			reuse = do_bg_work(event, eo_ctx);
+			break;
+
+		case CMD_DONE:	/* HB atomic queue */ {
+			e_state state = __atomic_load_n(&eo_ctx->state,
+							__ATOMIC_SEQ_CST);
+
+				if (state == STATE_RUN &&
+				    queue == eo_ctx->hb_q) {
+					__atomic_store_n(&eo_ctx->state,
+							 STATE_COOLOFF,
+							 __ATOMIC_SEQ_CST);
+					add_trace(eo_ctx, -1, OP_STATE,
+						  linux_time_ns(),
+						  STATE_COOLOFF);
+					eo_ctx->last_hbcount = last_count;
+					eo_ctx->stopped = get_time();
+					APPL_PRINT("Core %d DONE\n", msgin->id);
+				}
+			}
+			break;
+
+		default:
+			test_error(EM_ERROR_SET_FATAL(0xDEAD), 0xBEEF,
+				   "Invalid event!\n");
+		}
+	} else {
+		test_error(EM_ERROR_SET_FATAL(0xDEAD), 0xBEEF,
+			   "Invalid event type!\n");
+	}
+
+	if (!reuse)
+		em_free(event);
+}
+
+/**
+ * Main function
+ *
+ * Call cm_setup() to perform test & EM setup common for all the
+ * test applications.
+ *
+ * cm_setup() will call test_init() and test_start() and launch
+ * the EM dispatch loop on every EM-core.
+ *
+ * We're using command line arguments and pick those up before cm_setup
+ * since argv is not yet available in test_init().
+ */
+int main(int argc, char *argv[])
+{
+	/* pick app-specific arguments after '--' */
+	int i;
+
+	APPL_PRINT("EM periodic timer test %s\n\n", VERSION);
+
+	for (i = 1; i < argc; i++) {
+		if (!strcmp(argv[i], "--"))
+			break;
+	}
+	if (i < argc) {
+		if (!parse_my_args(i, argc, argv)) {
+			APPL_PRINT("Invalid application arguments\n");
+			return 1;
+		}
+	}
+
+	return cm_setup(argc, argv);
+}

--- a/programs/example/add-ons/timer_test_periodic.h
+++ b/programs/example/add-ons/timer_test_periodic.h
@@ -1,0 +1,183 @@
+#include <getopt.h>
+
+#define APP_EO_NAME	"testEO"
+#define DEF_TMO_DATA	100 /* per core, MAX_TMO_DATA * sizeof(tmo_data) */
+#define MAX_TMO_BYTES	1000000000ULL /* sanity limit 1GB per core */
+#define STOP_THRESHOLD	90 /* % of full buffer */
+#define MAX_CORES	64
+#define INIT_WAIT	5 /* startup wait, HBs */
+#define MEAS_PERIOD	5 /* freq meas HBs */
+#define DEF_MIN_PERIOD	10 /* min period default, N * res */
+#define USE_TIMER_STAT  0 /* 0 if EM does not support timer ack statistics */
+#define EXTRA_PRINTS	0 /* dev option, normally 0 */
+
+const struct option longopts[] = {
+	{"num-tmo",		required_argument, NULL, 'n'},
+	{"resolution",		required_argument, NULL, 'r'},
+	{"period",		required_argument, NULL, 'p'},
+	{"max-period",		required_argument, NULL, 'm'},
+	{"min-period",		required_argument, NULL, 'l'},
+	{"clk",			required_argument, NULL, 'c'},
+	{"write",		optional_argument, NULL, 'w'},
+	{"num-runs",		required_argument, NULL, 'x'},
+	{"tracebuf",		required_argument, NULL, 't'},
+	{"extra-work",		required_argument, NULL, 'e'},
+	{"background-job",	required_argument, NULL, 'j'},
+	{"noskip",		no_argument, NULL, 's'},
+	{"api-prof",		no_argument, NULL, 'a'},
+	{"dispatch-prof",	no_argument, NULL, 'd'},
+	{"job-prof",		no_argument, NULL, 'b'},
+	{"use-cpu-cycle",	optional_argument, NULL, 'g'},
+	{"help",		no_argument, NULL, 'h'},
+	{NULL, 0, NULL, 0}
+};
+
+const char *shortopts = "n:r:p:m:l:c:w::x:t:e:j:sadbg::h";
+/* descriptions for above options, keep in sync! */
+const char *descopts[] = {
+	"Number of concurrent timers to create",
+	"Resolution of test timer (ns)",
+	"Period of periodic test timer (ns). 0 for random",
+	"Maximum period (ns)",
+	"Minimum period (ns, only used for random tmo)",
+	"Clock source (integer. See event_machine_timer_hw_specific.h)",
+	"Write raw trace data in csv format to given file e.g.-wtest.csv (default stdout)",
+	"Number of test runs, 0 to run forever",
+	"Trace buffer size (events per core). Optional stop threshold % e.g. -t100,80 to stop 80% before full",
+	"Extra work per tmo: -e1,20,50 e.g. min_us,max_us,propability % of work",
+	"Extra background job: -j2,20,500,10 e.g. num,time_us,total_kB,chunk_kB",
+	"Create timer with NOSKIP option",
+	"Measure API calls",
+	"Include dispatcher trace (EO enter-exit)",
+	"Include bg job profile (note - can fill buffer quickly)",
+	"Use CPU cycles instead of ODP time. Optionally give frequency (hz)",
+	"Print usage and exit",
+	NULL
+};
+
+const char *instructions =
+"Controlled by command line arguments. Main purpose is to manually test\n"
+"periodic timer accuracy and behaviour optionally under (over)load.\n"
+"API overheads can also be measured\n"
+"\nTwo EM timers are created. One for a heartbeat driving test states. Second\n"
+"timer is used for testing the periodic timeouts. It can be created with\n"
+"given attributes to also test limits.\n\n"
+"Test runs in states:\n"
+"	STATE_INIT	let some time pass before starting to settle down\n"
+"	STATE_MEASURE	measure timer tick frequency against linux clock\n"
+"	STATE_STABILIZE finish all prints before starting run\n"
+"	STATE_RUN	timeouts creared and measured\n"
+"	STATE_COOLOFF	first core hitting trace buffer limit sets cooling,\n"
+"			i.e. coming timeout(s) are cancelled but not analyzed\n"
+"	STATE_ANALYZE	Statistics and trace file generation, restart\n"
+"\nBy default there is no background load and the handling of incoming\n"
+"timeouts (to high priority parallel queue) is minimized. Extra work can be\n"
+"added in two ways:\n\n"
+"1) --extra-work min us, max us, propability %\n"
+"	this will add random delay between min-max before calling ack().\n"
+"	Delay is added with the given propability (100 for all tmos)\n"
+"	e.g. -e10,100,50 to add random delay between 10 and 100us with 50%\n"
+"	propability\n"
+"2) --background-job  num,length us,total_kB,chunk_kB\n"
+"	this adds background work handled via separate low priority parallel\n"
+"	queue. num events are sent at start. Receiving touches given amount\n"
+"	of data (chunk at a time) for given amount of time and\n"
+"	then sends it again\n"
+"	e.g. -j1,10,500,20 adds one event of 10us processing over 20kB data\n"
+"	randomly picked from 500kB\n\n"
+"Test can write a file of measured timings (-w). It is in CSV format and can\n"
+"be imported e.g. to excel for plotting. -w without name prints to stdout\n";
+
+typedef enum e_op {
+	OP_TMO,
+	OP_HB,
+	OP_STATE,
+	OP_CANCEL,
+	OP_WORK,
+	OP_ACK,
+	OP_BGWORK,
+	OP_PROF_ACK,	/* linux time used as tick diff for each PROF */
+	OP_PROF_DELETE,
+	OP_PROF_CREATE,
+	OP_PROF_SET,
+	OP_PROF_ENTER_CB,
+	OP_PROF_EXIT_CB
+} e_op;
+const char *op_labels[] = {
+	"TMO",
+	"HB",
+	"STATE",
+	"CANCEL",
+	"WORK",
+	"ACK",
+	"BG-WORK",
+	"PROF-ACK",
+	"PROF-DEL",
+	"PROF-CREATE",
+	"PROF-SET",
+	"PROF-ENTER_CB",
+	"PROF-EXIT_CB"
+};
+
+typedef union time_stamp { /* to work around ODP time type vs CPU cycles */
+	uint64_t u64;
+	odp_time_t odp;
+} time_stamp;
+typedef struct tmo_trace {
+		int id;
+		e_op op;
+		uint64_t tick;
+		time_stamp ts;
+		time_stamp linuxt;
+		int count;
+} tmo_trace;
+
+#define RND_STATE_BUF   32
+typedef struct rnd_state_t {
+	struct random_data rdata;
+	char rndstate[RND_STATE_BUF];
+} rnd_state_t;
+
+typedef struct core_data {
+	int count ODP_ALIGNED_CACHE;
+	tmo_trace *trc;
+	int cancelled;
+	int jobs;
+	int jobs_deleted;
+	rnd_state_t rng;
+	time_stamp enter;
+	time_stamp acc_time;
+} core_data;
+
+typedef enum e_cmd {
+	CMD_HEARTBEAT,
+	CMD_TMO,
+	CMD_DONE,
+	CMD_BGWORK
+} e_cmd;
+
+typedef struct app_msg_t {
+	e_cmd command;
+	int count;
+	em_tmo_t tmo;
+	int id;
+	uint64_t arg;
+
+} app_msg_t;
+
+typedef enum e_state {
+	STATE_INIT,	/* before start */
+	STATE_MEASURE,	/* measure timer freq */
+	STATE_STABILIZE,/* finish all printing before tmo setup */
+	STATE_RUN,	/* timers running */
+	STATE_COOLOFF,	/* cores cancel timers */
+	STATE_ANALYZE	/* timestamps analyzed */
+} e_state;
+
+typedef struct tmo_setup {
+	time_stamp start_ts;
+	uint64_t start;
+	uint64_t period_ns;
+	uint64_t ticks;
+	uint64_t ack_late;
+} tmo_setup;

--- a/programs/packet_io/Makefile.am
+++ b/programs/packet_io/Makefile.am
@@ -1,14 +1,20 @@
 include $(top_srcdir)/programs/Makefile.inc
 
 noinst_PROGRAMS = loopback \
+		  loopback_multircv \
 		  loopback_ag \
 		  loopback_local \
+		  loopback_local_multircv \
 		  multi_stage \
 		  multi_stage_local
 
 loopback_LDFLAGS = $(AM_LDFLAGS) -static
 loopback_CFLAGS = $(AM_CFLAGS)
 loopback_CFLAGS += -I$(top_srcdir)/src
+
+loopback_multircv_LDFLAGS = $(AM_LDFLAGS) -static
+loopback_multircv_CFLAGS = $(AM_CFLAGS)
+loopback_multircv_CFLAGS += -I$(top_srcdir)/src
 
 loopback_ag_LDFLAGS = $(AM_LDFLAGS) -static
 loopback_ag_CFLAGS = $(AM_CFLAGS)
@@ -17,6 +23,10 @@ loopback_ag_CFLAGS += -I$(top_srcdir)/src
 loopback_local_LDFLAGS = $(AM_LDFLAGS) -static
 loopback_local_CFLAGS = $(AM_CFLAGS)
 loopback_local_CFLAGS += -I$(top_srcdir)/src
+
+loopback_local_multircv_LDFLAGS = $(AM_LDFLAGS) -static
+loopback_local_multircv_CFLAGS = $(AM_CFLAGS)
+loopback_local_multircv_CFLAGS += -I$(top_srcdir)/src
 
 multi_stage_LDFLAGS = $(AM_LDFLAGS) -static
 multi_stage_CFLAGS = $(AM_CFLAGS)
@@ -27,7 +37,9 @@ multi_stage_local_CFLAGS = $(AM_CFLAGS)
 multi_stage_local_CFLAGS += -I$(top_srcdir)/src
 
 dist_loopback_SOURCES = loopback.c
+dist_loopback_multircv_SOURCES = loopback_multircv.c
 dist_loopback_ag_SOURCES = loopback_ag.c
 dist_loopback_local_SOURCES = loopback_local.c
+dist_loopback_local_multircv_SOURCES = loopback_local_multircv.c
 dist_multi_stage_SOURCES = multi_stage.c
 dist_multi_stage_local_SOURCES = multi_stage_local.c

--- a/programs/packet_io/loopback_local_multircv.c
+++ b/programs/packet_io/loopback_local_multircv.c
@@ -1,0 +1,835 @@
+/*
+ *   Copyright (c) 2020, Nokia Solutions and Networks
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *
+ * Simple Load Balanced Packet-IO test application using local queues and
+ * capable of receiving multiple events at a time (the EO is created with a
+ * multi-event receive function).
+ *
+ * The application (EO) receives a batch of UDP datagrams and exchanges
+ * the src-dst addesses before sending the datagrams back out.
+ *
+ * Based on lopback_local.c
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <inttypes.h>
+
+#include <event_machine.h>
+#include <event_machine/platform/env/environment.h>
+
+#include "cm_setup.h"
+#include "cm_error_handler.h"
+#include "cm_pktio.h"
+
+/*
+ * Test configuration
+ */
+
+/**
+ * Set the used queue type for EM queues receiving packet data.
+ *
+ * Default: use EM_QUEUE_TYPE_LOCAL for max throughput by skipping
+ * load balancing and dynamic scheduling in favor of raw performance.
+ *
+ * Try also with EM_QUEUE_TYPE_ATOMIC, EM_QUEUE_TYPE_PARALLEL or
+ * EM_QUEUE_TYPE_PARALLEL_ORDERED.
+ * Alt. set QUEUE_TYPE_MIX to '1' to use all queue types simultaneously.
+ */
+#define QUEUE_TYPE  EM_QUEUE_TYPE_LOCAL
+/* #define QUEUE_TYPE  EM_QUEUE_TYPE_ATOMIC */
+/* #define QUEUE_TYPE  EM_QUEUE_TYPE_PARALLEL */
+/* #define QUEUE_TYPE  EM_QUEUE_TYPE_PARALLEL_ORDERED */
+
+/**
+ * Test with all different queue types simultaneously:
+ * LOCAL, ATOMIC, PARALLELL, PARALLEL_ORDERED
+ */
+#define QUEUE_TYPE_MIX  0 /* 0=False or 1=True */
+
+/**
+ * Create an EM queue per UDP/IP flow or use the default queue.
+ *
+ * If set to '0' then all traffic is routed through one 'default queue'(slow),
+ * if set to '1' each traffic flow is routed to its own EM-queue.
+ */
+#define QUEUE_PER_FLOW  1 /* 0=False or 1=True */
+
+/**
+ * Select whether the UDP ports should be unique over all the IP-interfaces
+ * (set to 1) or reused per IP-interface (thus each UDP port is configured
+ * once for  each IP-interface). Using '0' (not unique) makes it easier to
+ * copy traffic generator settings from one IF-port to another as only the
+ * dst-IP address has to be changed.
+ */
+#define UDP_PORTS_UNIQUE  0 /* 0=False or 1=True */
+
+/**
+ * Select whether the input and output ports should be cross-connected.
+ */
+#define X_CONNECT_PORTS  0 /* 0=False or 1=True */
+
+/**
+ * Enable per packet error checking
+ */
+#define ENABLE_ERROR_CHECKS  0 /* 0=False or 1=True */
+
+/**
+ * Test em_alloc and em_free per packet
+ *
+ * Alloc new event, copy event, free old event
+ */
+#define ALLOC_COPY_FREE  0 /* 0=False or 1=True */
+
+/* Configure the IP addresses and UDP ports that this application will use */
+#define NUM_IP_ADDRS      4
+#define NUM_PORTS_PER_IP  64
+
+#define IP_ADDR_A  192
+#define IP_ADDR_B  168
+#define IP_ADDR_C  1
+#define IP_ADDR_D  16
+
+#define IP_ADDR_BASE  ((IP_ADDR_A << 24) | (IP_ADDR_B << 16) | \
+		       (IP_ADDR_C << 8)  | (IP_ADDR_D))
+#define UDP_PORT_BASE  1024
+/*
+ * IANA Dynamic Ports (Private or Ephemeral Ports),
+ * from 49152 to 65535 (never assigned)
+ */
+/* #define UDP_PORT_BASE  0xC000 */
+
+#define MAX_NUM_IF 4 /* max number of used interfaces */
+#define MAX_IF_ID  6 /* max interface identifier:[0-MAX], cnt:MAX+1 */
+
+#define NUM_PKTIN_QUEUES  (NUM_IP_ADDRS * NUM_PORTS_PER_IP)
+#define MAX_PKTOUT_QUEUES_PER_IF  EM_MAX_CORES
+
+#define IS_ODD(x)   (((x) & 0x1))
+#define IS_EVEN(x)  (!IS_ODD(x))
+
+#define MAX_RCV_FN_EVENTS  256
+
+/**
+ * EO context
+ */
+typedef struct {
+	em_eo_t eo;
+	char name[32];
+	/** interface count as provided by appl_conf to test_start() */
+	int if_count;
+	/** interface ids as provided via appl_conf_t to test_start() */
+	int if_ids[MAX_NUM_IF];
+	/** default queue: pkts/events not matching any other input criteria */
+	em_queue_t default_queue;
+	/** all created input queues */
+	em_queue_t queue[NUM_PKTIN_QUEUES];
+	/** the number of packet output queues to use per interface */
+	int pktout_queues_per_if;
+	/* pktout queues: accessed by if_id, thus empty middle slots possible */
+	em_queue_t pktout_queue[MAX_IF_ID + 1][MAX_PKTOUT_QUEUES_PER_IF];
+} eo_context_t;
+
+/**
+ * Save the dst IP, protocol and port in the queue-context.
+ * Verify (if error checking enabled) that the received packet matches the
+ * configuration for the queue.
+ */
+typedef struct flow_params_ {
+	uint32_t ipv4;
+	uint16_t port;
+	uint8_t proto;
+	uint8_t _pad;
+} flow_params_t;
+
+/**
+ * Queue-Context, i.e. queue specific data, each queue has its own instance
+ */
+typedef struct {
+	/** a pktout queue for each interface, precalculated */
+	em_queue_t pktout_queue[MAX_IF_ID + 1];
+	/** saved flow params for the EM-queue */
+	flow_params_t flow_params;
+	/** queue handle */
+	em_queue_t queue;
+} queue_context_t;
+
+/**
+ * Packet Loopback shared memory
+ */
+typedef struct {
+	/** EO (application) context */
+	eo_context_t eo_ctx;
+	/**
+	 * Array containing the contexts of all the queues handled by the EO.
+	 * A queue context contains the flow/queue specific data for the
+	 * application EO.
+	 */
+	queue_context_t eo_q_ctx[NUM_PKTIN_QUEUES] ENV_CACHE_LINE_ALIGNED;
+
+	/** Queue context for the default queue */
+	queue_context_t def_q_ctx;
+} packet_loopback_shm_t;
+
+/** EM-core local pointer to shared memory */
+static ENV_LOCAL packet_loopback_shm_t *pkt_shm;
+
+static em_status_t
+start_eo(void *eo_context, em_eo_t eo, const em_eo_conf_t *conf);
+
+static void
+create_queue_per_flow(const em_eo_t eo, eo_context_t *const eo_ctx);
+
+static void
+set_pktout_queues(em_queue_t queue, eo_context_t *const eo_ctx,
+		  em_queue_t pktout_queue[/*out*/]);
+
+static em_status_t
+start_eo_local(void *eo_context, em_eo_t eo);
+
+static void
+receive_eo_packet_multi(void *eo_context, em_event_t event_tbl[], int num,
+			em_queue_t queue, void *queue_context);
+
+static em_status_t
+stop_eo(void *eo_context, em_eo_t eo);
+
+static inline int
+rx_error_check(eo_context_t *const eo_ctx, const em_event_t event,
+	       const em_queue_t queue, queue_context_t *const q_ctx);
+
+static inline em_event_t
+alloc_copy_free(em_event_t event);
+
+/**
+ * Main function
+ *
+ * Call cm_setup() to perform test & EM setup common for all the
+ * test applications.
+ *
+ * cm_setup() will call test_init() and test_start() and launch
+ * the EM dispatch loop on every EM-core.
+ */
+int main(int argc, char *argv[])
+{
+	return cm_setup(argc, argv);
+}
+
+/**
+ * Init of the Packet Loopback test application.
+ *
+ * @attention Run on all cores.
+ *
+ * @see cm_setup() for setup and dispatch.
+ */
+void
+test_init(void)
+{
+	int core = em_core_id();
+
+	if (core == 0) {
+		pkt_shm = env_shared_reserve("PktLoopShMem",
+					     sizeof(packet_loopback_shm_t));
+		em_register_error_handler(test_error_handler);
+	} else {
+		pkt_shm = env_shared_lookup("PktLoopShMem");
+	}
+
+	if (pkt_shm == NULL)
+		test_error(EM_ERROR_SET_FATAL(0xec0de), 0xdead,
+			   "Packet Loopback init failed on EM-core: %u",
+			   em_core_id());
+	else if (core == 0)
+		memset(pkt_shm, 0, sizeof(packet_loopback_shm_t));
+}
+
+/**
+ * Startup of the Packet Loopback test application.
+ *
+ * @attention Run only on EM core 0.
+ *
+ * @param appl_conf Application configuration
+ *
+ * @see cm_setup() for setup and dispatch.
+ */
+void
+test_start(appl_conf_t *const appl_conf)
+{
+	em_eo_t eo;
+	em_eo_multircv_param_t eo_param;
+	eo_context_t *eo_ctx;
+	em_status_t ret, start_fn_ret = EM_ERROR;
+	int if_id, i;
+
+	APPL_PRINT("\n"
+		   "***********************************************************\n"
+		   "EM APPLICATION: '%s' initializing:\n"
+		   "  %s: %s() - EM-core:%i\n"
+		   "  Application running on %d EM-cores (procs:%d, threads:%d)\n"
+		   "***********************************************************\n"
+		   "\n",
+		   appl_conf->name, NO_PATH(__FILE__), __func__, em_core_id(),
+		   em_core_count(),
+		   appl_conf->num_procs, appl_conf->num_threads);
+
+	test_fatal_if(appl_conf->pktio.if_count > MAX_NUM_IF ||
+		      appl_conf->pktio.if_count <= 0,
+		      "Invalid number of interfaces given:%d - need 1-%d(MAX)",
+		      appl_conf->pktio.if_count, MAX_NUM_IF);
+
+	/*
+	 * Create one EO
+	 */
+	eo_ctx = &pkt_shm->eo_ctx;
+	/* Initialize EO context data to '0' */
+	memset(eo_ctx, 0, sizeof(eo_context_t));
+
+	/* Init EO params */
+	em_eo_multircv_param_init(&eo_param);
+	/* Set EO params needed by this application */
+	eo_param.start = start_eo;
+	eo_param.local_start = start_eo_local;
+	eo_param.stop = stop_eo;
+	eo_param.receive_multi = receive_eo_packet_multi;
+	eo_param.max_events = MAX_RCV_FN_EVENTS;
+	eo_param.eo_ctx = eo_ctx;
+	eo = em_eo_create_multircv(appl_conf->name, &eo_param);
+	test_fatal_if(eo == EM_EO_UNDEF, "em_eo_create() failed");
+	eo_ctx->eo = eo;
+
+	/* Store the number of pktio interfaces used */
+	eo_ctx->if_count = appl_conf->pktio.if_count;
+	/* Store the used interface ids */
+	for (i = 0; i < appl_conf->pktio.if_count; i++) {
+		if_id = appl_conf->pktio.if_ids[i];
+		test_fatal_if(if_id > MAX_IF_ID,
+			      "Interface id out of range! %d > %d(MAX)",
+			      if_id, MAX_IF_ID);
+		eo_ctx->if_ids[i] = if_id;
+	}
+
+	/* Start the EO - queues etc. created in the EO start function */
+	ret = em_eo_start_sync(eo, &start_fn_ret, NULL);
+	test_fatal_if(ret != EM_OK || start_fn_ret != EM_OK,
+		      "em_eo_start_sync() failed:%" PRI_STAT " %" PRI_STAT "",
+		      ret, start_fn_ret);
+
+	/*
+	 * All input & output queues have been created and enabled in the
+	 * EO start function, now direct pktio traffic to those queues.
+	 */
+	for (i = 0; i < NUM_PKTIN_QUEUES; i++) {
+		/* Direct ip_addr:udp_port into this queue */
+		queue_context_t *q_ctx = &pkt_shm->eo_q_ctx[i];
+		uint32_t ip_addr = q_ctx->flow_params.ipv4;
+		uint16_t port = q_ctx->flow_params.port;
+		uint8_t proto = q_ctx->flow_params.proto;
+		em_queue_t queue = q_ctx->queue;
+		em_queue_t tmp_q;
+		char ip_str[sizeof("255.255.255.255")];
+
+		ipaddr_tostr(ip_addr, ip_str, sizeof(ip_str));
+
+		pktio_add_queue(proto, ip_addr, port, queue);
+
+		/* Sanity checks (lookup what was configured) */
+		tmp_q = pktio_lookup_sw(proto, ip_addr, port);
+		test_fatal_if(tmp_q == EM_QUEUE_UNDEF || tmp_q != queue,
+			      "Lookup fails IP:UDP %s:%d\n"
+			      "Q:%" PRI_QUEUE "!=%" PRI_QUEUE "",
+			      ip_str, port, queue, tmp_q);
+		/* Print first and last mapping */
+		if (i == 0 || i == NUM_PKTIN_QUEUES - 1)
+			APPL_PRINT("IP:prt->Q  %s:%u->%" PRI_QUEUE "\n",
+				   ip_str, port, tmp_q);
+	}
+
+	/*
+	 * Direct all non-lookup hit packets into this queue.
+	 * Note: if QUEUE_PER_FLOW is '0' then ALL packets end up in this queue
+	 */
+	pktio_default_queue(eo_ctx->default_queue);
+}
+
+void
+test_stop(appl_conf_t *const appl_conf)
+{
+	const int core = em_core_id();
+	eo_context_t *const eo_ctx = &pkt_shm->eo_ctx;
+	em_eo_t eo = eo_ctx->eo;
+	em_status_t ret;
+
+	(void)appl_conf;
+
+	APPL_PRINT("%s() on EM-core %d\n", __func__, core);
+
+	ret = em_eo_stop_sync(eo);
+	test_fatal_if(ret != EM_OK,
+		      "EO:%" PRI_EO " stop:%" PRI_STAT "", eo, ret);
+	ret = em_eo_delete(eo);
+	test_fatal_if(ret != EM_OK,
+		      "EO:%" PRI_EO " delete:%" PRI_STAT "", eo, ret);
+}
+
+void
+test_term(void)
+{
+	int core = em_core_id();
+
+	APPL_PRINT("%s() on EM-core %d\n", __func__, core);
+
+	if (core == 0) {
+		env_shared_free(pkt_shm);
+		em_unregister_error_handler();
+	}
+}
+
+/**
+ * EO start function (run once at startup on ONE core)
+ *
+ * The global start function creates the application specific queues and
+ * associates the queues with the EO and the packet flows it wants to process.
+ */
+static em_status_t
+start_eo(void *eo_context, em_eo_t eo, const em_eo_conf_t *conf)
+{
+	em_queue_t def_queue, pktout_queue;
+	em_queue_conf_t queue_conf;
+	em_output_queue_conf_t output_conf; /* platform specific */
+	pktio_tx_fn_args_t pktio_tx_fn_args; /* user defined content */
+	em_queue_type_t queue_type;
+	em_queue_group_t queue_group;
+	em_status_t ret;
+	eo_context_t *const eo_ctx = eo_context;
+	queue_context_t *defq_ctx;
+	int if_id;
+	int i, j;
+
+	(void)conf;
+
+	/* Store the EO name in the EO-context data */
+	em_eo_get_name(eo, eo_ctx->name, sizeof(eo_ctx->name));
+
+	APPL_PRINT("EO %" PRI_EO ":'%s' global start, if-count:%d\n",
+		   eo, eo_ctx->name, eo_ctx->if_count);
+
+	/*
+	 * Create packet output queues.
+	 *
+	 * Dimension the number of pktout queues to be equal to the number
+	 * of EM cores per interface to minimize output resource contention.
+	 */
+	test_fatal_if(em_core_count() >= MAX_PKTOUT_QUEUES_PER_IF,
+		      "No room to store pktout queues");
+	eo_ctx->pktout_queues_per_if = em_core_count();
+
+	memset(&queue_conf, 0, sizeof(queue_conf));
+	memset(&output_conf, 0, sizeof(output_conf));
+	queue_conf.flags = EM_QUEUE_FLAG_DEFAULT;
+	queue_conf.min_events = 0; /* system default */
+	queue_conf.conf_len = sizeof(output_conf);
+	queue_conf.conf = &output_conf;
+
+	/* Output-queue callback function (em_output_func_t) */
+	output_conf.output_fn = pktio_tx;
+	/* Callback function extra argument, here a 'pktio_tx_fn_args_t' ptr */
+	output_conf.output_fn_args = &pktio_tx_fn_args;
+	output_conf.args_len = sizeof(pktio_tx_fn_args_t);
+	/* Content of 'pktio_tx_fn_args' set in loop */
+
+	/* Create the packet output queues for each interface */
+	for (i = 0; i < eo_ctx->if_count; i++) {
+		if_id = eo_ctx->if_ids[i];
+		for (j = 0; j < eo_ctx->pktout_queues_per_if; j++) {
+			/* pktout queue tied to interface id 'if_id' */
+			pktio_tx_fn_args.if_id = if_id;
+			pktout_queue =
+			em_queue_create("pktout-queue", EM_QUEUE_TYPE_OUTPUT,
+					EM_QUEUE_PRIO_UNDEF,
+					EM_QUEUE_GROUP_UNDEF, &queue_conf);
+			test_fatal_if(pktout_queue == EM_QUEUE_UNDEF,
+				      "Pktout queue create failed:%d,%d", i, j);
+			eo_ctx->pktout_queue[if_id][j] = pktout_queue;
+		}
+	}
+
+	/*
+	 * Default queue for all packets not mathing any
+	 * specific input queue criteria
+	 */
+	queue_type = QUEUE_TYPE;
+	if (queue_type == EM_QUEUE_TYPE_LOCAL)
+		queue_group = EM_QUEUE_GROUP_UNDEF;
+	else
+		queue_group = EM_QUEUE_GROUP_DEFAULT;
+	def_queue = em_queue_create("default", queue_type, EM_QUEUE_PRIO_NORMAL,
+				    queue_group, NULL);
+	test_fatal_if(def_queue == EM_QUEUE_UNDEF,
+		      "Default Queue creation failed");
+
+	/* Store the default queue Id in the EO-context data */
+	eo_ctx->default_queue = def_queue;
+
+	/* Associate the queue with this EO */
+	ret = em_eo_add_queue_sync(eo, def_queue);
+	test_fatal_if(ret != EM_OK,
+		      "Add queue failed:%" PRI_STAT "\n"
+		      "EO:%" PRI_EO " Queue:%" PRI_QUEUE "",
+		      ret, eo, def_queue);
+
+	/* Set queue context for the default queue */
+	defq_ctx = &pkt_shm->def_q_ctx;
+	ret = em_queue_set_context(eo_ctx->default_queue, defq_ctx);
+	test_fatal_if(ret != EM_OK,
+		      "Set Q-ctx for the default queue failed:%" PRI_STAT "\n"
+		      "default-Q:%" PRI_QUEUE "", ret, def_queue);
+
+	/* Set the pktout queues to use for the default queue, one per if */
+	set_pktout_queues(def_queue, eo_ctx, defq_ctx->pktout_queue/*out*/);
+
+	if (QUEUE_PER_FLOW)
+		create_queue_per_flow(eo, eo_ctx);
+
+	APPL_PRINT("EO %" PRI_EO " global start done.\n", eo);
+
+	return EM_OK;
+}
+
+/**
+ * Helper func for EO start() to create a queue per packet flow (if configured)
+ */
+static void
+create_queue_per_flow(const em_eo_t eo, eo_context_t *const eo_ctx)
+{
+	uint16_t port_offset = (uint16_t)-1;
+	uint32_t q_ctx_idx = 0;
+	queue_context_t *q_ctx;
+	em_queue_type_t qtype;
+	em_queue_group_t queue_group;
+	em_queue_t queue;
+	em_status_t ret;
+	int i, j;
+
+	memset(pkt_shm->eo_q_ctx, 0, sizeof(pkt_shm->eo_q_ctx));
+
+	for (i = 0; i < NUM_IP_ADDRS; i++) {
+		char ip_str[sizeof("255.255.255.255")];
+		uint32_t ip_addr = IP_ADDR_BASE + i;
+
+		ipaddr_tostr(ip_addr, ip_str, sizeof(ip_str));
+
+		for (j = 0; j < NUM_PORTS_PER_IP; j++) {
+			uint16_t udp_port;
+
+			if (UDP_PORTS_UNIQUE) /* Every UDP-port is different */
+				port_offset++;
+			else /* Same UDP-ports per IP-interface */
+				port_offset = j;
+
+			udp_port = UDP_PORT_BASE + port_offset;
+
+			if (!QUEUE_TYPE_MIX) {
+				/* Use only queues of a single type */
+				qtype = QUEUE_TYPE;
+			} else {
+				/* Spread out over the 4 diff queue-types */
+				int nbr_q = ((i * NUM_PORTS_PER_IP) + j) % 4;
+
+				if (nbr_q == 0)
+					qtype = EM_QUEUE_TYPE_LOCAL;
+				else if (nbr_q == 1)
+					qtype = EM_QUEUE_TYPE_ATOMIC;
+				else if (nbr_q == 2)
+					qtype = EM_QUEUE_TYPE_PARALLEL;
+				else
+					qtype = EM_QUEUE_TYPE_PARALLEL_ORDERED;
+			}
+
+			/* Create a queue */
+			if (qtype == EM_QUEUE_TYPE_LOCAL)
+				queue_group = EM_QUEUE_GROUP_UNDEF;
+			else
+				queue_group = EM_QUEUE_GROUP_DEFAULT;
+			queue = em_queue_create("udp-flow", qtype,
+						EM_QUEUE_PRIO_NORMAL,
+						queue_group, NULL);
+			test_fatal_if(queue == EM_QUEUE_UNDEF,
+				      "Queue create failed: UDP-port %d",
+				      udp_port);
+			/*
+			 * Store the id of the created queue into the
+			 * application specific EO-context
+			 */
+			eo_ctx->queue[q_ctx_idx] = queue;
+
+			/* Set queue specific appl (EO) context */
+			q_ctx = &pkt_shm->eo_q_ctx[q_ctx_idx];
+			/* Save flow params */
+			q_ctx->flow_params.ipv4 = ip_addr;
+			q_ctx->flow_params.port = udp_port;
+			q_ctx->flow_params.proto = IPV4_PROTO_UDP;
+			q_ctx->queue = queue;
+
+			ret = em_queue_set_context(queue, q_ctx);
+			test_fatal_if(ret != EM_OK,
+				      "Set Q-ctx failed:%" PRI_STAT "\n"
+				      "EO-q-ctx:%d Q:%" PRI_QUEUE "",
+				      ret, q_ctx_idx, queue);
+
+			/* Add the queue to the EO */
+			ret = em_eo_add_queue_sync(eo, queue);
+			test_fatal_if(ret != EM_OK,
+				      "Add queue failed:%" PRI_STAT "\n"
+				      "EO:%" PRI_EO " Q:%" PRI_QUEUE "",
+				      ret, eo, queue);
+
+			/*
+			 * Set the pktout queues to use for this input queue,
+			 * one pktout queue per interface.
+			 */
+			set_pktout_queues(queue, eo_ctx,
+					  q_ctx->pktout_queue/*out*/);
+
+			/* Update the Queue Context Index */
+			q_ctx_idx++;
+			test_fatal_if(q_ctx_idx > NUM_PKTIN_QUEUES,
+				      "Too many queues!");
+		}
+	}
+}
+
+/**
+ * Helper func to store the packet output queues for a specific input queue
+ */
+static void
+set_pktout_queues(em_queue_t queue, eo_context_t *const eo_ctx,
+		  em_queue_t pktout_queue[/*out*/])
+{
+	int if_count = eo_ctx->if_count;
+	int pktout_idx = (uintptr_t)queue % eo_ctx->pktout_queues_per_if;
+	int id, i;
+
+	for (i = 0; i < if_count; i++) {
+		id = eo_ctx->if_ids[i];
+		pktout_queue[id] = eo_ctx->pktout_queue[id][pktout_idx];
+	}
+}
+
+/**
+ * EO Local start function (run once at startup on EACH core)
+
+ * Not really needed in this application, but included
+ * to demonstrate usage.
+ */
+static em_status_t
+start_eo_local(void *eo_context, em_eo_t eo)
+{
+	eo_context_t *eo_ctx = eo_context;
+
+	APPL_PRINT("EO %" PRI_EO ":%s local start on EM-core%u\n",
+		   eo, eo_ctx->name, em_core_id());
+
+	return EM_OK;
+}
+
+/**
+ * EO stop function
+ */
+static em_status_t
+stop_eo(void *eo_context, em_eo_t eo)
+{
+	eo_context_t *eo_ctx = eo_context;
+	em_status_t ret;
+	em_queue_t pktout_queue;
+	int if_id;
+	int i, j;
+
+	APPL_PRINT("EO %" PRI_EO ":%s stopping\n", eo, eo_ctx->name);
+
+	/* remove and delete all of the EO's queues */
+	ret = em_eo_remove_queue_all_sync(eo, EM_TRUE);
+	test_fatal_if(ret != EM_OK,
+		      "EO remove queue all:%" PRI_STAT " EO:%" PRI_EO "",
+		      ret, eo);
+
+	/* Delete the packet output queues created for each interface */
+	for (i = 0; i < eo_ctx->if_count; i++) {
+		if_id = eo_ctx->if_ids[i];
+		for (j = 0; j < eo_ctx->pktout_queues_per_if; j++) {
+			/* pktout queue tied to interface id 'if_id' */
+			pktout_queue = eo_ctx->pktout_queue[if_id][j];
+			test_fatal_if(pktout_queue == EM_QUEUE_UNDEF,
+				      "Pktout queue undef:%d,%d", i, j);
+			ret = em_queue_delete(pktout_queue);
+			test_fatal_if(ret != EM_OK,
+				      "Pktout queue delete failed:%d,%d", i, j);
+		}
+	}
+
+	return EM_OK;
+}
+
+/**
+ * EO event receive function
+ */
+static void
+receive_eo_packet_multi(void *eo_context, em_event_t event_tbl[], int num,
+			em_queue_t queue, void *queue_context)
+{
+	queue_context_t *const q_ctx = queue_context;
+	int in_port;
+	int out_port;
+	em_queue_t pktout_queue;
+	int ret, i;
+
+	if (unlikely(appl_shm->exit_flag)) {
+		em_free_multi(event_tbl, num);
+		return;
+	}
+
+	in_port = pktio_input_port(event_tbl[0]);
+
+	if (X_CONNECT_PORTS)
+		out_port = IS_EVEN(in_port) ? in_port + 1 : in_port - 1;
+	else
+		out_port = in_port;
+
+	pktout_queue = q_ctx->pktout_queue[out_port];
+
+	if (ENABLE_ERROR_CHECKS) {
+		eo_context_t *const eo_ctx = eo_context;
+
+		for (i = 0; i < num; i++)
+			if (rx_error_check(eo_ctx, event_tbl[i],
+					   queue, q_ctx) != 0)
+				return;
+	}
+
+	/* Touch packet. Swap MAC, IP-addrs and UDP-ports: scr<->dst */
+	for (i = 0; i < num; i++)
+		pktio_swap_addrs(event_tbl[i]);
+
+	if (ALLOC_COPY_FREE) /* alloc event, copy contents & free original */
+		for (i = 0; i < num; i++)
+			event_tbl[i] = alloc_copy_free(event_tbl[i]);
+
+	/*
+	 * Send the packet buffer back out via the pktout queue through
+	 * the 'out_port'
+	 */
+	ret = em_send_multi(event_tbl, num, pktout_queue);
+	if (unlikely(ret != num))
+		em_free_multi(&event_tbl[ret], num - ret);
+}
+
+static inline int
+rx_error_check(eo_context_t *const eo_ctx, const em_event_t event,
+	       const em_queue_t queue, queue_context_t *const q_ctx)
+{
+	static ENV_LOCAL uint64_t drop_cnt = 1;
+	uint8_t proto;
+	uint32_t ipv4_dst;
+	uint16_t port_dst;
+
+	pktio_get_dst(event, &proto, &ipv4_dst, &port_dst);
+
+	if (QUEUE_PER_FLOW) {
+		flow_params_t *fp;
+
+		/* Drop everything from the default queue */
+		if (unlikely(queue == eo_ctx->default_queue)) {
+			char ip_str[sizeof("255.255.255.255")];
+
+			ipaddr_tostr(ipv4_dst, ip_str, sizeof(ip_str));
+
+			APPL_PRINT("Pkt %s:%" PRIu16 " defQ drop-%d-#%" PRIu64 "\n",
+				   ip_str, port_dst, em_core_id(), drop_cnt++);
+
+			pktio_drop(event);
+			return -1;
+		}
+
+		/*
+		 * Check IP address and port: compare packet against the stored
+		 * values in the queue context
+		 */
+		fp = &q_ctx->flow_params;
+		test_fatal_if(fp->ipv4 != ipv4_dst ||
+			      fp->port != port_dst || fp->proto != proto,
+			      "Q:%" PRI_QUEUE " received illegal packet!\n"
+			      "rcv: IP:0x%" PRIx32 ":%" PRIu16 ".%" PRIu8 "\n"
+			      "cfg: IP:0x%" PRIx32 ":%" PRIu16 ".%" PRIu8 "\n"
+			      "Abort!", queue, ipv4_dst, port_dst, proto,
+			      fp->ipv4, fp->port, fp->proto);
+	} else {
+		if (unlikely(proto != IPV4_PROTO_UDP)) {
+			APPL_PRINT("Pkt: defQ, not UDP drop-%d-#%" PRIu64 "\n",
+				   em_core_id(), drop_cnt++);
+			pktio_drop(event);
+			return -1;
+		}
+
+		test_fatal_if(ipv4_dst < (uint32_t)IP_ADDR_BASE ||
+			      ipv4_dst >=
+			      (uint32_t)(IP_ADDR_BASE + NUM_IP_ADDRS) ||
+			      port_dst < UDP_PORT_BASE ||
+			      port_dst >= (UDP_PORT_BASE + NUM_PKTIN_QUEUES) ||
+			      proto != IPV4_PROTO_UDP,
+			      "Q:%" PRI_QUEUE " received illegal packet!\n"
+			      "rcv: IP:0x%" PRIx32 ":%" PRIu16 ".%" PRIu8 "\n"
+			      "Values not in the configurated range!\n"
+			      "Abort!",
+			      queue, ipv4_dst, port_dst, proto);
+	}
+
+	/* Everything OK, return zero */
+	return 0;
+}
+
+/**
+ * Alloc a new event, copy the contents&header into the new event
+ * and finally free the original event. Returns a pointer to the new event.
+ *
+ * Used for testing the performance impact of alloc-copy-free operations.
+ */
+static inline em_event_t
+alloc_copy_free(em_event_t event)
+{
+	/* Copy the packet event */
+	em_event_t new_event = pktio_copy_event(event);
+
+	/* Free old event */
+	em_free(event);
+
+	return new_event;
+}

--- a/programs/packet_io/loopback_multircv.c
+++ b/programs/packet_io/loopback_multircv.c
@@ -1,0 +1,815 @@
+/*
+ *   Copyright (c) 2020, Nokia Solutions and Networks
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *
+ * Simple Load Balanced Packet-IO test application capable of receiving multiple
+ * events at a time (the EO is created with a multi-event receive function)
+ *
+ * The application (EO) receives a batch of UDP datagrams and exchanges
+ * the src-dst addesses before sending the datagrams back out.
+ *
+ * Based on the loopback.c application
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <inttypes.h>
+
+#include <event_machine.h>
+#include <event_machine/platform/env/environment.h>
+
+#include "cm_setup.h"
+#include "cm_error_handler.h"
+#include "cm_pktio.h"
+
+/*
+ * Test configuration
+ */
+
+/**
+ * Set the used queue type for EM queues receiving packet data.
+ *
+ * Try also with EM_QUEUE_TYPE_PARALLEL or EM_QUEUE_TYPE_PARALLEL_ORDERED.
+ * Alt. set QUEUE_TYPE_MIX to '1' to use all queue types simultaneously.
+ */
+#define QUEUE_TYPE  EM_QUEUE_TYPE_ATOMIC
+/* #define QUEUE_TYPE  EM_QUEUE_TYPE_PARALLEL */
+/* #define QUEUE_TYPE  EM_QUEUE_TYPE_PARALLEL_ORDERED */
+
+/**
+ * Test with all different queue types simultaneously:
+ * ATOMIC, PARALLELL, PARALLEL_ORDERED
+ */
+#define QUEUE_TYPE_MIX  0 /* 0=False or 1=True */
+
+/**
+ * Create an EM queue per UDP/IP flow or use the default queue.
+ *
+ * If set to '0' then all traffic is routed through one 'default queue'(slow),
+ * if set to '1' each traffic flow is routed to its own EM-queue.
+ */
+#define QUEUE_PER_FLOW  1 /* 0=False or 1=True */
+
+/**
+ * Select whether the UDP ports should be unique over all the IP-interfaces
+ * (set to 1) or reused per IP-interface (thus each UDP port is configured
+ * once for  each IP-interface). Using '0' (not unique) makes it easier to
+ * copy traffic generator settings from one IF-port to another as only the
+ * dst-IP address has to be changed.
+ */
+#define UDP_PORTS_UNIQUE  0 /* 0=False or 1=True */
+
+/**
+ * Select whether the input and output ports should be cross-connected.
+ */
+#define X_CONNECT_PORTS  0 /* 0=False or 1=True */
+
+/**
+ * Enable per packet error checking
+ */
+#define ENABLE_ERROR_CHECKS  0 /* 0=False or 1=True */
+
+/**
+ * Test em_alloc and em_free per packet
+ *
+ * Alloc new event, copy event, free old event
+ */
+#define ALLOC_COPY_FREE  0 /* 0=False or 1=True */
+
+/* Configure the IP addresses and UDP ports that this application will use */
+#define NUM_IP_ADDRS      4
+#define NUM_PORTS_PER_IP  64
+
+#define IP_ADDR_A  192
+#define IP_ADDR_B  168
+#define IP_ADDR_C  1
+#define IP_ADDR_D  16
+
+#define IP_ADDR_BASE  ((IP_ADDR_A << 24) | (IP_ADDR_B << 16) | \
+		       (IP_ADDR_C << 8)  | (IP_ADDR_D))
+#define UDP_PORT_BASE  1024
+/*
+ * IANA Dynamic Ports (Private or Ephemeral Ports),
+ * from 49152 to 65535 (never assigned)
+ */
+/* #define UDP_PORT_BASE  0xC000 */
+
+#define MAX_NUM_IF 4 /* max number of used interfaces */
+#define MAX_IF_ID  6 /* max interface identifier:[0-MAX], cnt:MAX+1 */
+
+#define NUM_PKTIN_QUEUES  (NUM_IP_ADDRS * NUM_PORTS_PER_IP)
+#define MAX_PKTOUT_QUEUES_PER_IF  EM_MAX_CORES
+
+#define IS_ODD(x)   (((x) & 0x1))
+#define IS_EVEN(x)  (!IS_ODD(x))
+
+#define MAX_RCV_FN_EVENTS  256
+
+/**
+ * EO context
+ */
+typedef struct {
+	em_eo_t eo;
+	char name[32];
+	/** interface count as provided by appl_conf to test_start() */
+	int if_count;
+	/** interface ids as provided via appl_conf_t to test_start() */
+	int if_ids[MAX_NUM_IF];
+	/** default queue: pkts/events not matching any other input criteria */
+	em_queue_t default_queue;
+	/** all created input queues */
+	em_queue_t queue[NUM_PKTIN_QUEUES];
+	/** the number of packet output queues to use per interface */
+	int pktout_queues_per_if;
+	/* pktout queues: accessed by if_id, thus empty middle slots possible */
+	em_queue_t pktout_queue[MAX_IF_ID + 1][MAX_PKTOUT_QUEUES_PER_IF];
+} eo_context_t;
+
+/**
+ * Save the dst IP, protocol and port in the queue-context.
+ * Verify (if error checking enabled) that the received packet matches the
+ * configuration for the queue.
+ */
+typedef struct flow_params_ {
+	uint32_t ipv4;
+	uint16_t port;
+	uint8_t proto;
+	uint8_t _pad;
+} flow_params_t;
+
+/**
+ * Queue-Context, i.e. queue specific data, each queue has its own instance
+ */
+typedef struct {
+	/** a pktout queue for each interface, precalculated */
+	em_queue_t pktout_queue[MAX_IF_ID + 1];
+	/** saved flow params for the EM-queue */
+	flow_params_t flow_params;
+	/** queue handle */
+	em_queue_t queue;
+} queue_context_t;
+
+/**
+ * Packet Loopback shared memory
+ */
+typedef struct {
+	/** EO (application) context */
+	eo_context_t eo_ctx;
+	/**
+	 * Array containing the contexts of all the queues handled by the EO.
+	 * A queue context contains the flow/queue specific data for the
+	 * application EO.
+	 */
+	queue_context_t eo_q_ctx[NUM_PKTIN_QUEUES] ENV_CACHE_LINE_ALIGNED;
+
+	/** Queue context for the default queue */
+	queue_context_t def_q_ctx;
+} packet_loopback_shm_t;
+
+/** EM-core local pointer to shared memory */
+static ENV_LOCAL packet_loopback_shm_t *pkt_shm;
+
+static em_status_t
+start_eo(void *eo_context, em_eo_t eo, const em_eo_conf_t *conf);
+
+static void
+create_queue_per_flow(const em_eo_t eo, eo_context_t *const eo_ctx);
+
+static void
+set_pktout_queues(em_queue_t queue, eo_context_t *const eo_ctx,
+		  em_queue_t pktout_queue[/*out*/]);
+
+static em_status_t
+start_eo_local(void *eo_context, em_eo_t eo);
+
+static void
+receive_eo_packet_multi(void *eo_context, em_event_t event_tbl[], int num,
+			em_queue_t queue, void *queue_context);
+
+static em_status_t
+stop_eo(void *eo_context, em_eo_t eo);
+
+static inline int
+rx_error_check(eo_context_t *const eo_ctx, const em_event_t event,
+	       const em_queue_t queue, queue_context_t *const q_ctx);
+
+static inline em_event_t
+alloc_copy_free(em_event_t event);
+
+/**
+ * Main function
+ *
+ * Call cm_setup() to perform test & EM setup common for all the
+ * test applications.
+ *
+ * cm_setup() will call test_init() and test_start() and launch
+ * the EM dispatch loop on every EM-core.
+ */
+int main(int argc, char *argv[])
+{
+	return cm_setup(argc, argv);
+}
+
+/**
+ * Init of the Packet Loopback test application.
+ *
+ * @attention Run on all cores.
+ *
+ * @see cm_setup() for setup and dispatch.
+ */
+void
+test_init(void)
+{
+	int core = em_core_id();
+
+	if (core == 0) {
+		pkt_shm = env_shared_reserve("PktLoopShMem",
+					     sizeof(packet_loopback_shm_t));
+		em_register_error_handler(test_error_handler);
+	} else {
+		pkt_shm = env_shared_lookup("PktLoopShMem");
+	}
+
+	if (pkt_shm == NULL)
+		test_error(EM_ERROR_SET_FATAL(0xec0de), 0xdead,
+			   "Packet Loopback init failed on EM-core: %u",
+			   em_core_id());
+	else if (core == 0)
+		memset(pkt_shm, 0, sizeof(packet_loopback_shm_t));
+}
+
+/**
+ * Startup of the Packet Loopback test application.
+ *
+ * @attention Run only on EM core 0.
+ *
+ * @param appl_conf Application configuration
+ *
+ * @see cm_setup() for setup and dispatch.
+ */
+void
+test_start(appl_conf_t *const appl_conf)
+{
+	em_eo_t eo;
+	em_eo_multircv_param_t eo_param;
+	eo_context_t *eo_ctx;
+	em_status_t ret, start_fn_ret = EM_ERROR;
+	int if_id, i;
+
+	APPL_PRINT("\n"
+		   "***********************************************************\n"
+		   "EM APPLICATION: '%s' initializing:\n"
+		   "  %s: %s() - EM-core:%i\n"
+		   "  Application running on %d EM-cores (procs:%d, threads:%d)\n"
+		   "***********************************************************\n"
+		   "\n",
+		   appl_conf->name, NO_PATH(__FILE__), __func__, em_core_id(),
+		   em_core_count(),
+		   appl_conf->num_procs, appl_conf->num_threads);
+
+	test_fatal_if(appl_conf->pktio.if_count > MAX_NUM_IF ||
+		      appl_conf->pktio.if_count <= 0,
+		      "Invalid number of interfaces given:%d - need 1-%d(MAX)",
+		      appl_conf->pktio.if_count, MAX_NUM_IF);
+
+	/*
+	 * Create one EO
+	 */
+	eo_ctx = &pkt_shm->eo_ctx;
+	/* Initialize EO context data to '0' */
+	memset(eo_ctx, 0, sizeof(eo_context_t));
+
+	/* Init EO params */
+	em_eo_multircv_param_init(&eo_param);
+	/* Set EO params needed by this application */
+	eo_param.start = start_eo;
+	eo_param.local_start = start_eo_local;
+	eo_param.stop = stop_eo;
+	eo_param.receive_multi = receive_eo_packet_multi;
+	eo_param.max_events = MAX_RCV_FN_EVENTS;
+	eo_param.eo_ctx = eo_ctx;
+	eo = em_eo_create_multircv(appl_conf->name, &eo_param);
+	test_fatal_if(eo == EM_EO_UNDEF, "em_eo_create() failed");
+	eo_ctx->eo = eo;
+
+	/* Store the number of pktio interfaces used */
+	eo_ctx->if_count = appl_conf->pktio.if_count;
+	/* Store the used interface ids */
+	for (i = 0; i < appl_conf->pktio.if_count; i++) {
+		if_id = appl_conf->pktio.if_ids[i];
+		test_fatal_if(if_id > MAX_IF_ID,
+			      "Interface id out of range! %d > %d(MAX)",
+			      if_id, MAX_IF_ID);
+		eo_ctx->if_ids[i] = if_id;
+	}
+
+	/* Start the EO - queues etc. created in the EO start function */
+	ret = em_eo_start_sync(eo, &start_fn_ret, NULL);
+	test_fatal_if(ret != EM_OK || start_fn_ret != EM_OK,
+		      "em_eo_start_sync() failed:%" PRI_STAT " %" PRI_STAT "",
+		      ret, start_fn_ret);
+
+	/*
+	 * All input & output queues have been created and enabled in the
+	 * EO start function, now direct pktio traffic to those queues.
+	 */
+	for (i = 0; i < NUM_PKTIN_QUEUES; i++) {
+		/* Direct ip_addr:udp_port into this queue */
+		queue_context_t *q_ctx = &pkt_shm->eo_q_ctx[i];
+		uint32_t ip_addr = q_ctx->flow_params.ipv4;
+		uint16_t port = q_ctx->flow_params.port;
+		uint8_t proto = q_ctx->flow_params.proto;
+		em_queue_t queue = q_ctx->queue;
+		em_queue_t tmp_q;
+		char ip_str[sizeof("255.255.255.255")];
+
+		ipaddr_tostr(ip_addr, ip_str, sizeof(ip_str));
+
+		pktio_add_queue(proto, ip_addr, port, queue);
+
+		/* Sanity checks (lookup what was configured) */
+		tmp_q = pktio_lookup_sw(proto, ip_addr, port);
+		test_fatal_if(tmp_q == EM_QUEUE_UNDEF || tmp_q != queue,
+			      "Lookup fails IP:UDP %s:%d\n"
+			      "Q:%" PRI_QUEUE "!=%" PRI_QUEUE "",
+			      ip_str, port, queue, tmp_q);
+		/* Print first and last mapping */
+		if (i == 0 || i == NUM_PKTIN_QUEUES - 1)
+			APPL_PRINT("IP:prt->Q  %s:%u->%" PRI_QUEUE "\n",
+				   ip_str, port, tmp_q);
+	}
+
+	/*
+	 * Direct all non-lookup hit packets into this queue.
+	 * Note: if QUEUE_PER_FLOW is '0' then ALL packets end up in this queue
+	 */
+	pktio_default_queue(eo_ctx->default_queue);
+}
+
+void
+test_stop(appl_conf_t *const appl_conf)
+{
+	const int core = em_core_id();
+	eo_context_t *const eo_ctx = &pkt_shm->eo_ctx;
+	em_eo_t eo = eo_ctx->eo;
+	em_status_t ret;
+
+	(void)appl_conf;
+
+	APPL_PRINT("%s() on EM-core %d\n", __func__, core);
+
+	ret = em_eo_stop_sync(eo);
+	test_fatal_if(ret != EM_OK,
+		      "EO:%" PRI_EO " stop:%" PRI_STAT "", eo, ret);
+	ret = em_eo_delete(eo);
+	test_fatal_if(ret != EM_OK,
+		      "EO:%" PRI_EO " delete:%" PRI_STAT "", eo, ret);
+}
+
+void
+test_term(void)
+{
+	int core = em_core_id();
+
+	APPL_PRINT("%s() on EM-core %d\n", __func__, core);
+
+	if (core == 0) {
+		env_shared_free(pkt_shm);
+		em_unregister_error_handler();
+	}
+}
+
+/**
+ * EO start function (run once at startup on ONE core)
+ *
+ * The global start function creates the application specific queues and
+ * associates the queues with the EO and the packet flows it wants to process.
+ */
+static em_status_t
+start_eo(void *eo_context, em_eo_t eo, const em_eo_conf_t *conf)
+{
+	em_queue_t def_queue, pktout_queue;
+	em_queue_conf_t queue_conf;
+	em_output_queue_conf_t output_conf; /* platform specific */
+	pktio_tx_fn_args_t pktio_tx_fn_args; /* user defined content */
+	em_status_t ret;
+	eo_context_t *const eo_ctx = eo_context;
+	queue_context_t *defq_ctx;
+	int if_id;
+	int i, j;
+
+	(void)conf;
+
+	/* Store the EO name in the EO-context data */
+	em_eo_get_name(eo, eo_ctx->name, sizeof(eo_ctx->name));
+
+	APPL_PRINT("EO %" PRI_EO ":'%s' global start, if-count:%d\n",
+		   eo, eo_ctx->name, eo_ctx->if_count);
+
+	/*
+	 * Create packet output queues.
+	 *
+	 * Dimension the number of pktout queues to be equal to the number
+	 * of EM cores per interface to minimize output resource contention.
+	 */
+	test_fatal_if(em_core_count() >= MAX_PKTOUT_QUEUES_PER_IF,
+		      "No room to store pktout queues");
+	eo_ctx->pktout_queues_per_if = em_core_count();
+
+	memset(&queue_conf, 0, sizeof(queue_conf));
+	memset(&output_conf, 0, sizeof(output_conf));
+	queue_conf.flags = EM_QUEUE_FLAG_DEFAULT;
+	queue_conf.min_events = 0; /* system default */
+	queue_conf.conf_len = sizeof(output_conf);
+	queue_conf.conf = &output_conf;
+
+	/* Output-queue callback function (em_output_func_t) */
+	output_conf.output_fn = pktio_tx;
+	/* Callback function extra argument, here a 'pktio_tx_fn_args_t' ptr */
+	output_conf.output_fn_args = &pktio_tx_fn_args;
+	output_conf.args_len = sizeof(pktio_tx_fn_args_t);
+	/* Content of 'pktio_tx_fn_args' set in loop */
+
+	/* Create the packet output queues for each interface */
+	for (i = 0; i < eo_ctx->if_count; i++) {
+		if_id = eo_ctx->if_ids[i];
+		for (j = 0; j < eo_ctx->pktout_queues_per_if; j++) {
+			/* pktout queue tied to interface id 'if_id' */
+			pktio_tx_fn_args.if_id = if_id;
+			pktout_queue =
+			em_queue_create("pktout-queue", EM_QUEUE_TYPE_OUTPUT,
+					EM_QUEUE_PRIO_UNDEF,
+					EM_QUEUE_GROUP_UNDEF, &queue_conf);
+			test_fatal_if(pktout_queue == EM_QUEUE_UNDEF,
+				      "Pktout queue create failed:%d,%d", i, j);
+			eo_ctx->pktout_queue[if_id][j] = pktout_queue;
+		}
+	}
+
+	/*
+	 * Default queue for all packets not mathing any
+	 * specific input queue criteria
+	 */
+	def_queue = em_queue_create("default", QUEUE_TYPE, EM_QUEUE_PRIO_NORMAL,
+				    EM_QUEUE_GROUP_DEFAULT, NULL);
+	test_fatal_if(def_queue == EM_QUEUE_UNDEF,
+		      "Default Queue creation failed");
+
+	/* Store the default queue Id in the EO-context data */
+	eo_ctx->default_queue = def_queue;
+
+	/* Associate the queue with this EO */
+	ret = em_eo_add_queue_sync(eo, def_queue);
+	test_fatal_if(ret != EM_OK,
+		      "Add queue failed:%" PRI_STAT "\n"
+		      "EO:%" PRI_EO " queue:%" PRI_QUEUE "",
+		      ret, eo, def_queue);
+
+	/* Set queue context for the default queue */
+	defq_ctx = &pkt_shm->def_q_ctx;
+	ret = em_queue_set_context(eo_ctx->default_queue, defq_ctx);
+	test_fatal_if(ret != EM_OK,
+		      "Set Q-ctx for the default queue failed:%" PRI_STAT "\n"
+		      "default-Q:%" PRI_QUEUE "", ret, def_queue);
+
+	/* Set the pktout queues to use for the default queue, one per if */
+	set_pktout_queues(def_queue, eo_ctx, defq_ctx->pktout_queue/*out*/);
+
+	if (QUEUE_PER_FLOW)
+		create_queue_per_flow(eo, eo_ctx);
+
+	APPL_PRINT("EO %" PRI_EO " global start done.\n", eo);
+
+	return EM_OK;
+}
+
+/**
+ * Helper func for EO start() to create a queue per packet flow (if configured)
+ */
+static void
+create_queue_per_flow(const em_eo_t eo, eo_context_t *const eo_ctx)
+{
+	uint16_t port_offset = (uint16_t)-1;
+	uint32_t q_ctx_idx = 0;
+	queue_context_t *q_ctx;
+	em_queue_type_t qtype;
+	em_queue_t queue;
+	em_status_t ret;
+	int i, j;
+
+	memset(pkt_shm->eo_q_ctx, 0, sizeof(pkt_shm->eo_q_ctx));
+
+	for (i = 0; i < NUM_IP_ADDRS; i++) {
+		char ip_str[sizeof("255.255.255.255")];
+		uint32_t ip_addr = IP_ADDR_BASE + i;
+
+		ipaddr_tostr(ip_addr, ip_str, sizeof(ip_str));
+
+		for (j = 0; j < NUM_PORTS_PER_IP; j++) {
+			uint16_t udp_port;
+
+			if (UDP_PORTS_UNIQUE) /* Every UDP-port is different */
+				port_offset++;
+			else /* Same UDP-ports per IP-interface */
+				port_offset = j;
+
+			udp_port = UDP_PORT_BASE + port_offset;
+
+			if (!QUEUE_TYPE_MIX) {
+				/* Use only queues of a single type */
+				qtype = QUEUE_TYPE;
+			} else {
+				/* Spread out over the 3 diff queue-types */
+				int nbr_q = ((i * NUM_PORTS_PER_IP) + j) % 3;
+
+				if (nbr_q == 0)
+					qtype = EM_QUEUE_TYPE_ATOMIC;
+				else if (nbr_q == 1)
+					qtype = EM_QUEUE_TYPE_PARALLEL;
+				else
+					qtype = EM_QUEUE_TYPE_PARALLEL_ORDERED;
+			}
+
+			/* Create a queue */
+			queue = em_queue_create("udp-flow", qtype,
+						EM_QUEUE_PRIO_NORMAL,
+						EM_QUEUE_GROUP_DEFAULT, NULL);
+			test_fatal_if(queue == EM_QUEUE_UNDEF,
+				      "Queue create failed: UDP-port %d",
+				      udp_port);
+			/*
+			 * Store the id of the created queue into the
+			 * application specific EO-context
+			 */
+			eo_ctx->queue[q_ctx_idx] = queue;
+
+			/* Set queue specific appl (EO) context */
+			q_ctx = &pkt_shm->eo_q_ctx[q_ctx_idx];
+			/* Save flow params */
+			q_ctx->flow_params.ipv4 = ip_addr;
+			q_ctx->flow_params.port = udp_port;
+			q_ctx->flow_params.proto = IPV4_PROTO_UDP;
+			q_ctx->queue = queue;
+
+			ret = em_queue_set_context(queue, q_ctx);
+			test_fatal_if(ret != EM_OK,
+				      "Set Q-ctx failed:%" PRI_STAT "\n"
+				      "EO-q-ctx:%d Q:%" PRI_QUEUE "",
+				      ret, q_ctx_idx, queue);
+
+			/* Add the queue to the EO */
+			ret = em_eo_add_queue_sync(eo, queue);
+			test_fatal_if(ret != EM_OK,
+				      "Add queue failed:%" PRI_STAT "\n"
+				      "EO:%" PRI_EO " Q:%" PRI_QUEUE "",
+				      ret, eo, queue);
+
+			/*
+			 * Set the pktout queues to use for this input queue,
+			 * one pktout queue per interface.
+			 */
+			set_pktout_queues(queue, eo_ctx,
+					  q_ctx->pktout_queue/*out*/);
+
+			/* Update the Queue Context Index */
+			q_ctx_idx++;
+			test_fatal_if(q_ctx_idx > NUM_PKTIN_QUEUES,
+				      "Too many queues!");
+		}
+	}
+}
+
+/**
+ * Helper func to store the packet output queues for a specific input queue
+ */
+static void
+set_pktout_queues(em_queue_t queue, eo_context_t *const eo_ctx,
+		  em_queue_t pktout_queue[/*out*/])
+{
+	int if_count = eo_ctx->if_count;
+	int pktout_idx = (uintptr_t)queue % eo_ctx->pktout_queues_per_if;
+	int id, i;
+
+	for (i = 0; i < if_count; i++) {
+		id = eo_ctx->if_ids[i];
+		pktout_queue[id] = eo_ctx->pktout_queue[id][pktout_idx];
+	}
+}
+
+/**
+ * EO Local start function (run once at startup on EACH core)
+
+ * Not really needed in this application, but included
+ * to demonstrate usage.
+ */
+static em_status_t
+start_eo_local(void *eo_context, em_eo_t eo)
+{
+	eo_context_t *eo_ctx = eo_context;
+
+	APPL_PRINT("EO %" PRI_EO ":%s local start on EM-core%u\n",
+		   eo, eo_ctx->name, em_core_id());
+
+	return EM_OK;
+}
+
+/**
+ * EO stop function
+ */
+static em_status_t
+stop_eo(void *eo_context, em_eo_t eo)
+{
+	eo_context_t *eo_ctx = eo_context;
+	em_status_t ret;
+	em_queue_t pktout_queue;
+	int if_id;
+	int i, j;
+
+	APPL_PRINT("EO %" PRI_EO ":%s stopping\n", eo, eo_ctx->name);
+
+	/* remove and delete all of the EO's queues */
+	ret = em_eo_remove_queue_all_sync(eo, EM_TRUE);
+	test_fatal_if(ret != EM_OK,
+		      "EO remove queue all:%" PRI_STAT " EO:%" PRI_EO "",
+		      ret, eo);
+
+	/* Delete the packet output queues created for each interface */
+	for (i = 0; i < eo_ctx->if_count; i++) {
+		if_id = eo_ctx->if_ids[i];
+		for (j = 0; j < eo_ctx->pktout_queues_per_if; j++) {
+			/* pktout queue tied to interface id 'if_id' */
+			pktout_queue = eo_ctx->pktout_queue[if_id][j];
+			test_fatal_if(pktout_queue == EM_QUEUE_UNDEF,
+				      "Pktout queue undef:%d,%d", i, j);
+			ret = em_queue_delete(pktout_queue);
+			test_fatal_if(ret != EM_OK,
+				      "Pktout queue delete failed:%d,%d", i, j);
+		}
+	}
+
+	return EM_OK;
+}
+
+/**
+ * EO event receive function
+ */
+static void
+receive_eo_packet_multi(void *eo_context, em_event_t event_tbl[], int num,
+			em_queue_t queue, void *queue_context)
+{
+	queue_context_t *const q_ctx = queue_context;
+	int in_port;
+	int out_port;
+	em_queue_t pktout_queue;
+	int ret, i;
+
+	if (unlikely(appl_shm->exit_flag)) {
+		em_free_multi(event_tbl, num);
+		return;
+	}
+
+	in_port = pktio_input_port(event_tbl[0]);
+
+	if (X_CONNECT_PORTS)
+		out_port = IS_EVEN(in_port) ? in_port + 1 : in_port - 1;
+	else
+		out_port = in_port;
+
+	pktout_queue = q_ctx->pktout_queue[out_port];
+
+	if (ENABLE_ERROR_CHECKS) {
+		eo_context_t *const eo_ctx = eo_context;
+
+		for (i = 0; i < num; i++)
+			if (rx_error_check(eo_ctx, event_tbl[i],
+					   queue, q_ctx) != 0)
+				return;
+	}
+
+	/* Touch packet. Swap MAC, IP-addrs and UDP-ports: scr<->dst */
+	for (i = 0; i < num; i++)
+		pktio_swap_addrs(event_tbl[i]);
+
+	if (ALLOC_COPY_FREE) /* alloc event, copy contents & free original */
+		for (i = 0; i < num; i++)
+			event_tbl[i] = alloc_copy_free(event_tbl[i]);
+
+	/*
+	 * Send the packet buffer back out via the pktout queue through
+	 * the 'out_port'
+	 */
+	ret = em_send_multi(event_tbl, num, pktout_queue);
+	if (unlikely(ret != num))
+		em_free_multi(&event_tbl[ret], num - ret);
+}
+
+static inline int
+rx_error_check(eo_context_t *const eo_ctx, const em_event_t event,
+	       const em_queue_t queue, queue_context_t *const q_ctx)
+{
+	static ENV_LOCAL uint64_t drop_cnt = 1;
+	uint8_t proto;
+	uint32_t ipv4_dst;
+	uint16_t port_dst;
+
+	pktio_get_dst(event, &proto, &ipv4_dst, &port_dst);
+
+	if (QUEUE_PER_FLOW) {
+		flow_params_t *fp;
+
+		/* Drop everything from the default queue */
+		if (unlikely(queue == eo_ctx->default_queue)) {
+			char ip_str[sizeof("255.255.255.255")];
+
+			ipaddr_tostr(ipv4_dst, ip_str, sizeof(ip_str));
+
+			APPL_PRINT("Pkt %s:%" PRIu16 " defQ drop-%d-#%" PRIu64 "\n",
+				   ip_str, port_dst, em_core_id(), drop_cnt++);
+
+			pktio_drop(event);
+			return -1;
+		}
+
+		/*
+		 * Check IP address and port: compare packet against the stored
+		 * values in the queue context
+		 */
+		fp = &q_ctx->flow_params;
+		test_fatal_if(fp->ipv4 != ipv4_dst ||
+			      fp->port != port_dst || fp->proto != proto,
+			      "Q:%" PRI_QUEUE " received illegal packet!\n"
+			      "rcv: IP:0x%" PRIx32 ":%" PRIu16 ".%" PRIu8 "\n"
+			      "cfg: IP:0x%" PRIx32 ":%" PRIu16 ".%" PRIu8 "\n"
+			      "Abort!", queue, ipv4_dst, port_dst, proto,
+			      fp->ipv4, fp->port, fp->proto);
+	} else {
+		if (unlikely(proto != IPV4_PROTO_UDP)) {
+			APPL_PRINT("Pkt: defQ, not UDP drop-%d-#%" PRIu64 "\n",
+				   em_core_id(), drop_cnt++);
+			pktio_drop(event);
+			return -1;
+		}
+
+		test_fatal_if(ipv4_dst < (uint32_t)IP_ADDR_BASE ||
+			      ipv4_dst >=
+			      (uint32_t)(IP_ADDR_BASE + NUM_IP_ADDRS) ||
+			      port_dst < UDP_PORT_BASE ||
+			      port_dst >= (UDP_PORT_BASE + NUM_PKTIN_QUEUES) ||
+			      proto != IPV4_PROTO_UDP,
+			      "Q:%" PRI_QUEUE " received illegal packet!\n"
+			      "rcv: IP:0x%" PRIx32 ":%" PRIu16 ".%" PRIu8 "\n"
+			      "Values not in the configurated range!\n"
+			      "Abort!",
+			      queue, ipv4_dst, port_dst, proto);
+	}
+
+	/* Everything OK, return zero */
+	return 0;
+}
+
+/**
+ * Alloc a new event, copy the contents&header into the new event
+ * and finally free the original event. Returns a pointer to the new event.
+ *
+ * Used for testing the performance impact of alloc-copy-free operations.
+ */
+static inline em_event_t
+alloc_copy_free(em_event_t event)
+{
+	/* Copy the packet event */
+	em_event_t new_event = pktio_copy_event(event);
+
+	/* Free old event */
+	em_free(event);
+
+	return new_event;
+}

--- a/programs/performance/Makefile.am
+++ b/programs/performance/Makefile.am
@@ -3,6 +3,7 @@ include $(top_srcdir)/programs/Makefile.inc
 noinst_PROGRAMS = atomic_processing_end \
 		  pairs \
 		  loop \
+		  loop_multircv \
 		  queue_groups \
 		  queues \
 		  queues_unscheduled \
@@ -17,6 +18,9 @@ pairs_CFLAGS = $(AM_CFLAGS)
 
 loop_LDFLAGS = $(AM_LDFLAGS) -static
 loop_CFLAGS = $(AM_CFLAGS)
+
+loop_multircv_LDFLAGS = $(AM_LDFLAGS) -static
+loop_multircv_CFLAGS = $(AM_CFLAGS)
 
 queue_groups_LDFLAGS = $(AM_LDFLAGS) -static
 queue_groups_CFLAGS = $(AM_CFLAGS)
@@ -36,6 +40,7 @@ send_multi_CFLAGS = $(AM_CFLAGS)
 dist_atomic_processing_end_SOURCES = atomic_processing_end.c
 dist_pairs_SOURCES = pairs.c
 dist_loop_SOURCES = loop.c
+dist_loop_multircv_SOURCES = loop_multircv.c
 dist_queue_groups_SOURCES = queue_groups.c
 dist_queues_SOURCES = queues.c
 dist_queues_unscheduled_SOURCES = queues_unscheduled.c

--- a/programs/performance/loop_multircv.c
+++ b/programs/performance/loop_multircv.c
@@ -1,0 +1,469 @@
+/*
+ *   Copyright (c) 2020, Nokia Solutions and Networks
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *
+ * Event Machine performance test example - based on loop.c but uses
+ * a multi-event EO-receive function.
+ *
+ * Measures the average cycles consumed during an event send-sched-receive loop
+ * for a certain number of EOs in the system. The test has a number of EOs, each
+ * with one queue. Each EO receives events through its dedicated queue and
+ * sends them right back into the same queue, thus looping the events.
+ *
+ * Based on the 'pairs' performance test, but instead of forwarding events
+ * between queues, here we loop them back into the same queue (which is usually
+ * faster). Also 'loop' only uses one queue priority level.
+ */
+
+#include <inttypes.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <event_machine.h>
+#include <event_machine/platform/env/environment.h>
+
+#include "cm_setup.h"
+#include "cm_error_handler.h"
+
+/*
+ * Test configuration
+ */
+
+/** Number of test EOs and queues. Must be an even number. */
+#define NUM_EO  128
+
+/** Number of events per queue */
+#define NUM_EVENT_PER_QUEUE  128  /* Increase the value to tune performance */
+
+/** sizeof data[DATA_SIZE] in bytes in the event payload */
+#define DATA_SIZE  250
+
+/** Max number of cores */
+#define MAX_NBR_OF_CORES  256
+
+/** The number of events to be received before printing a result */
+#define PRINT_EVENT_COUNT  0xff0000
+
+/** EM Queue type used */
+#define QUEUE_TYPE  EM_QUEUE_TYPE_ATOMIC
+
+/** Define how many events are sent per em_send_multi() call */
+#define SEND_MULTI_MAX 32
+
+#define MAX_RCV_FN_EVENTS  32
+
+/*
+ * Options
+ */
+
+/** Alloc and free per event */
+#define ALLOC_FREE_PER_EVENT  0 /* 0=False or 1=True */
+
+/* Result APPL_PRINT() format string */
+#define RESULT_PRINTF_FMT \
+"cycles/event:% -8.2f  Mevents/s/core: %-6.2f %5.0f MHz  core%02d %" PRIu64 "\n"
+
+/**
+ * Performance test statistics (per core)
+ */
+typedef struct {
+	int64_t event_count;
+	uint64_t begin_cycles;
+	uint64_t end_cycles;
+	uint64_t print_count;
+} perf_stat_t;
+
+/**
+ * Performance test event
+ */
+typedef struct {
+	uint8_t data[DATA_SIZE];
+} perf_event_t;
+
+/**
+ * Perf test shared memory, read-only after start-up, allow cache-line sharing
+ */
+typedef struct {
+	/* EO table */
+	em_eo_t eo_tbl[NUM_EO];
+	/* Event pool used by this application */
+	em_pool_t pool;
+} perf_shm_t;
+
+/** EM-core local pointer to shared memory */
+static ENV_LOCAL perf_shm_t *perf_shm;
+/**
+ * Core specific test statistics.
+ *
+ * Allow for 'PRINT_EVENT_COUNT' warm-up rounds,
+ * incremented per core during receive, measurement starts at 0.
+ */
+static ENV_LOCAL perf_stat_t core_stat = {.event_count = 0};
+
+/*
+ * Local function prototypes
+ */
+
+static em_status_t
+perf_start(void *eo_context, em_eo_t eo, const em_eo_conf_t *conf);
+
+static em_status_t
+perf_stop(void *eo_context, em_eo_t eo);
+
+static void
+perf_receive_multi(void *eo_context, em_event_t event_tbl[], int num,
+		   em_queue_t queue, void *queue_context);
+
+static void
+print_result(perf_stat_t *const perf_stat);
+
+/**
+ * Main function
+ *
+ * Call cm_setup() to perform test & EM setup common for all the
+ * test applications.
+ *
+ * cm_setup() will call test_init() and test_start() and launch
+ * the EM dispatch loop on every EM-core.
+ */
+int main(int argc, char *argv[])
+{
+	return cm_setup(argc, argv);
+}
+
+/**
+ * Init of the Loop performance test application.
+ *
+ * @attention Run on all cores.
+ *
+ * @see cm_setup() for setup and dispatch.
+ */
+void
+test_init(void)
+{
+	int core = em_core_id();
+
+	if (core == 0) {
+		perf_shm = env_shared_reserve("PerfSharedMem",
+					      sizeof(perf_shm_t));
+		em_register_error_handler(test_error_handler);
+	} else {
+		perf_shm = env_shared_lookup("PerfSharedMem");
+	}
+
+	if (perf_shm == NULL)
+		test_error(EM_ERROR_SET_FATAL(0xec0de), 0xdead,
+			   "Perf init failed on EM-core:%u", em_core_id());
+	else if (core == 0)
+		memset(perf_shm, 0, sizeof(perf_shm_t));
+}
+
+/**
+ * Startup of the Loop performance test application.
+ *
+ * @attention Run only on EM core 0.
+ *
+ * @param appl_conf Application configuration
+ *
+ * @see cm_setup() for setup and dispatch.
+ */
+void
+test_start(appl_conf_t *const appl_conf)
+{
+	/*
+	 * Store the event pool to use, use the EM default pool if no other
+	 * pool is provided through the appl_conf.
+	 */
+	if (appl_conf->num_pools >= 1)
+		perf_shm->pool = appl_conf->pools[0];
+	else
+		perf_shm->pool = EM_POOL_DEFAULT;
+
+	APPL_PRINT("\n"
+		   "***********************************************************\n"
+		   "EM APPLICATION: '%s' initializing:\n"
+		   "  %s: %s() - EM-core:%i\n"
+		   "  Application running on %d EM-cores (procs:%d, threads:%d)\n"
+		   "  using event pool:%" PRI_POOL "\n"
+		   "***********************************************************\n"
+		   "\n",
+		   appl_conf->name, NO_PATH(__FILE__), __func__, em_core_id(),
+		   em_core_count(),
+		   appl_conf->num_procs, appl_conf->num_threads,
+		   perf_shm->pool);
+
+	test_fatal_if(perf_shm->pool == EM_POOL_UNDEF,
+		      "Undefined application event pool!");
+
+	/*
+	 * Create and start application EOs
+	 * Send initial test events to the EOs' queues
+	 */
+	em_queue_t queues[NUM_EO];
+
+	for (int i = 0; i < NUM_EO; i++) {
+		em_queue_t queue;
+		em_eo_t eo;
+		em_eo_multircv_param_t eo_param;
+		em_status_t ret, start_ret = EM_OK;
+
+		/* Create the EO's loop queue */
+		queue = em_queue_create("queue A", QUEUE_TYPE,
+					EM_QUEUE_PRIO_NORMAL,
+					EM_QUEUE_GROUP_DEFAULT, NULL);
+		test_fatal_if(queue == EM_QUEUE_UNDEF,
+			      "Queue creation failed, round:%d", i);
+		queues[i] = queue;
+
+		/* Init & create the EO */
+		em_eo_multircv_param_init(&eo_param);
+		/* Set EO params needed by this application */
+		eo_param.start = perf_start;
+		eo_param.stop = perf_stop;
+		eo_param.receive_multi = perf_receive_multi;
+		/* eo_param.max_events = use default; */
+		eo = em_eo_create_multircv("loop-eo", &eo_param);
+		test_fatal_if(eo == EM_EO_UNDEF,
+			      "EO(%d) creation failed!", i);
+		perf_shm->eo_tbl[i] = eo;
+
+		ret = em_eo_add_queue_sync(eo, queue);
+		test_fatal_if(ret != EM_OK,
+			      "EO add queue:%" PRI_STAT "\n"
+			      "EO:%" PRI_EO " Queue:%" PRI_QUEUE "",
+			      ret, eo, queue);
+
+		ret = em_eo_start_sync(eo, &start_ret, NULL);
+		test_fatal_if(ret != EM_OK || start_ret != EM_OK,
+			      "EO start:%" PRI_STAT " %" PRI_STAT "",
+			      ret, start_ret);
+	}
+
+	for (int i = 0; i < NUM_EO; i++) {
+		em_queue_t queue = queues[i];
+		em_event_t events[NUM_EVENT_PER_QUEUE];
+		int num, tot = 0;
+
+		/* Alloc and send test events */
+		do {
+			num = em_alloc_multi(events, NUM_EVENT_PER_QUEUE - tot,
+					     sizeof(perf_event_t),
+					     EM_EVENT_TYPE_SW, perf_shm->pool);
+			tot += num;
+		} while (tot < num && num > 0);
+		test_fatal_if(tot != NUM_EVENT_PER_QUEUE,
+			      "Allocated:%d of requested:%d events",
+			      tot, NUM_EVENT_PER_QUEUE);
+
+		/* Send in bursts of 'SEND_MULTI_MAX' events */
+		const int send_rounds = NUM_EVENT_PER_QUEUE / SEND_MULTI_MAX;
+		const int left_over = NUM_EVENT_PER_QUEUE % SEND_MULTI_MAX;
+		int num_sent = 0;
+		int m, n;
+
+		for (m = 0, n = 0; m < send_rounds; m++, n += SEND_MULTI_MAX) {
+			num_sent += em_send_multi(&events[n], SEND_MULTI_MAX,
+						  queue);
+		}
+		if (left_over) {
+			num_sent += em_send_multi(&events[n], left_over,
+					  queue);
+		}
+		test_fatal_if(num_sent != NUM_EVENT_PER_QUEUE,
+			      "Event send multi failed:%d (%d)\n"
+			      "Q:%" PRI_QUEUE "",
+			      num_sent, NUM_EVENT_PER_QUEUE, queue);
+	}
+
+	env_sync_mem();
+}
+
+void
+test_stop(appl_conf_t *const appl_conf)
+{
+	const int core = em_core_id();
+	em_eo_t eo;
+	em_status_t ret;
+	int i;
+
+	(void)appl_conf;
+
+	APPL_PRINT("%s() on EM-core %d\n", __func__, core);
+
+	for (i = 0; i < NUM_EO; i++) {
+		/* Stop & delete EO */
+		eo = perf_shm->eo_tbl[i];
+
+		ret = em_eo_stop_sync(eo);
+		test_fatal_if(ret != EM_OK,
+			      "EO:%" PRI_EO " stop:%" PRI_STAT "", eo, ret);
+
+		ret = em_eo_delete(eo);
+		test_fatal_if(ret != EM_OK,
+			      "EO:%" PRI_EO " delete:%" PRI_STAT "", eo, ret);
+	}
+}
+
+void
+test_term(void)
+{
+	const int core = em_core_id();
+
+	APPL_PRINT("%s() on EM-core %d\n", __func__, core);
+
+	if (core == 0) {
+		env_shared_free(perf_shm);
+		em_unregister_error_handler();
+	}
+}
+
+/**
+ * @private
+ *
+ * EO start function.
+ *
+ */
+static em_status_t
+perf_start(void *eo_context, em_eo_t eo, const em_eo_conf_t *conf)
+{
+	(void)eo_context;
+	(void)eo;
+	(void)conf;
+
+	return EM_OK;
+}
+
+/**
+ * @private
+ *
+ * EO stop function.
+ *
+ */
+static em_status_t
+perf_stop(void *eo_context, em_eo_t eo)
+{
+	em_status_t ret;
+
+	(void)eo_context;
+
+	/* remove and delete all of the EO's queues */
+	ret = em_eo_remove_queue_all_sync(eo, EM_TRUE);
+	test_fatal_if(ret != EM_OK,
+		      "EO remove queue all:%" PRI_STAT " EO:%" PRI_EO "",
+		      ret, eo);
+	return ret;
+}
+
+/**
+ * @private
+ *
+ * EO receive function for EO A.
+ *
+ * Loops back events and calculates the event rate.
+ */
+static void
+perf_receive_multi(void *eo_context, em_event_t event_tbl[], int num,
+		   em_queue_t queue, void *queue_context)
+{
+	int64_t event_count = core_stat.event_count;
+	int ret;
+
+	(void)eo_context;
+	(void)queue_context;
+
+	if (unlikely(appl_shm->exit_flag)) {
+		em_free_multi(event_tbl, num);
+		return;
+	}
+
+	if (unlikely(event_count == 0)) {
+		/* Start the measurement */
+		core_stat.begin_cycles = env_get_cycle();
+	} else if (unlikely(event_count >= PRINT_EVENT_COUNT)) {
+		/* End the measurement */
+		core_stat.end_cycles = env_get_cycle();
+		/* Print results and restart */
+		core_stat.print_count += 1;
+		print_result(&core_stat);
+		/* Restart the measurement next round */
+		event_count = -num; /* +num below => 0 */
+	}
+
+	if (ALLOC_FREE_PER_EVENT) {
+		em_free_multi(event_tbl, num);
+		int ret = em_alloc_multi(event_tbl, num, sizeof(perf_event_t),
+			       EM_EVENT_TYPE_SW, perf_shm->pool);
+		test_fatal_if(ret != num, "Allocated %d of num:%d events",
+			      ret, num);
+	}
+
+	/* Send the event back into the queue it originated from, i.e. loop */
+	ret = em_send_multi(event_tbl, num, queue);
+	if (unlikely(ret != num)) {
+		em_free_multi(&event_tbl[ret], num - ret);
+		test_fatal_if(!appl_shm->exit_flag,
+			      "Send-multi:%d Num:%d Queue:%" PRI_QUEUE "",
+			      ret, num, queue);
+	}
+
+	event_count += num;
+	core_stat.event_count = event_count;
+}
+
+/**
+ * Prints test measurement result
+ */
+static void
+print_result(perf_stat_t *const perf_stat)
+{
+	uint64_t diff;
+	uint32_t hz;
+	double mhz;
+	double cycles_per_event, events_per_sec;
+	uint64_t print_count;
+
+	hz = env_core_hz();
+	mhz = ((double)hz) / 1000000.0;
+
+	if (perf_stat->end_cycles > perf_stat->begin_cycles)
+		diff = perf_stat->end_cycles - perf_stat->begin_cycles;
+	else
+		diff = UINT64_MAX - perf_stat->begin_cycles +
+			perf_stat->end_cycles + 1;
+
+	print_count = perf_stat->print_count;
+	cycles_per_event = ((double)diff) / ((double)perf_stat->event_count);
+	events_per_sec = mhz / cycles_per_event; /* Million events/s */
+
+	APPL_PRINT(RESULT_PRINTF_FMT, cycles_per_event, events_per_sec,
+		   mhz, em_core_id(), print_count);
+}

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -51,7 +51,7 @@ my %ignore_type = ();
 my @ignore = ();
 my $help = 0;
 my $configuration_file = ".checkpatch.conf";
-my $max_line_length = 80;
+my $max_line_length = 100;
 my $ignore_perl_version = 0;
 my $minimum_perl_version = 5.10.0;
 my $min_conf_desc_length = 4;
@@ -64,6 +64,7 @@ my $color = "auto";
 my $allow_c99_comments = 1; # Can be overridden by --ignore C99_COMMENT_TOLERANCE
 # git output parsing needs US English output, so first set backtick child process LANGUAGE
 my $git_command ='export LANGUAGE=en_US.UTF-8; git';
+my $tabsize = 8;
 
 sub help {
 	my ($exitcode) = @_;
@@ -96,8 +97,11 @@ Options:
   --types TYPE(,TYPE2...)    show only these comma separated message types
   --ignore TYPE(,TYPE2...)   ignore various comma separated message types
   --show-types               show the specific message type in the output
-  --max-line-length=n        set the maximum line length, if exceeded, warn
+  --max-line-length=n        set the maximum line length, (default $max_line_length)
+                             if exceeded, warn on patches
+                             requires --strict for use with --file
   --min-conf-desc-length=n   set the min description length, if shorter, warn
+  --tab-size=n               set the number of spaces for tab (default $tabsize)
   --root=PATH                PATH to the kernel tree root
   --no-summary               suppress the per-file summary
   --mailback                 only produce a report in case of warnings/errors
@@ -215,6 +219,7 @@ GetOptions(
 	'list-types!'	=> \$list_types,
 	'max-line-length=i' => \$max_line_length,
 	'min-conf-desc-length=i' => \$min_conf_desc_length,
+	'tab-size=i'	=> \$tabsize,
 	'root=s'	=> \$root,
 	'summary!'	=> \$summary,
 	'mailback!'	=> \$mailback,
@@ -241,6 +246,8 @@ list_types(0) if ($list_types);
 $fix = 1 if ($fix_inplace);
 $check_orig = $check;
 
+die "$P: --git cannot be used with --file or --fix\n" if ($git && ($file || $fix));
+
 my $exit = 0;
 
 my $perl_version_ok = 1;
@@ -264,8 +271,11 @@ if ($color =~ /^[01]$/) {
 } elsif ($color =~ /^auto$/i) {
 	$color = (-t STDOUT);
 } else {
-	die "Invalid color mode: $color\n";
+	die "$P: Invalid color mode: $color\n";
 }
+
+# skip TAB size 1 to avoid additional checks on $tabsize - 1
+die "$P: Invalid TAB size: $tabsize\n" if ($tabsize < 2);
 
 sub hash_save_array_words {
 	my ($hashRef, $arrayRef) = @_;
@@ -473,7 +483,7 @@ our $allocFunctions = qr{(?x:
 		(?:kv|k|v)[czm]alloc(?:_node|_array)? |
 		kstrdup(?:_const)? |
 		kmemdup(?:_nul)?) |
-	(?:\w+)?alloc_skb(?:ip_align)? |
+	(?:\w+)?alloc_skb(?:_ip_align)? |
 				# dev_alloc_skb/netdev_alloc_skb, et al
 	dma_alloc_coherent
 )};
@@ -804,12 +814,12 @@ sub build_types {
 		  }x;
 	$Type	= qr{
 			$NonptrType
-			(?:(?:\s|\*|\[\])+\s*const|(?:\s|\*\s*(?:const\s*)?|\[\])+|(?:\s*\[\s*\])+)?
+			(?:(?:\s|\*|\[\])+\s*const|(?:\s|\*\s*(?:const\s*)?|\[\])+|(?:\s*\[\s*\])+){0,4}
 			(?:\s+$Inline|\s+$Modifier)*
 		  }x;
 	$TypeMisordered	= qr{
 			$NonptrTypeMisordered
-			(?:(?:\s|\*|\[\])+\s*const|(?:\s|\*\s*(?:const\s*)?|\[\])+|(?:\s*\[\s*\])+)?
+			(?:(?:\s|\*|\[\])+\s*const|(?:\s|\*\s*(?:const\s*)?|\[\])+|(?:\s*\[\s*\])+){0,4}
 			(?:\s+$Inline|\s+$Modifier)*
 		  }x;
 	$Declare	= qr{(?:$Storage\s+(?:$Inline\s+)?)?$Type};
@@ -1052,6 +1062,7 @@ for my $filename (@ARGV) {
 	while (<$FILE>) {
 		chomp;
 		push(@rawlines, $_);
+		$vname = qq("$1") if ($filename eq '-' && $_ =~ m/^Subject:\s+(.+)/i);
 	}
 	close($FILE);
 
@@ -1118,6 +1129,7 @@ sub parse_email {
 	my ($formatted_email) = @_;
 
 	my $name = "";
+	my $name_comment = "";
 	my $address = "";
 	my $comment = "";
 
@@ -1150,6 +1162,10 @@ sub parse_email {
 
 	$name = trim($name);
 	$name =~ s/^\"|\"$//g;
+	$name =~ s/(\s*\([^\)]+\))\s*//;
+	if (defined($1)) {
+		$name_comment = trim($1);
+	}
 	$address = trim($address);
 	$address =~ s/^\<|\>$//g;
 
@@ -1158,7 +1174,7 @@ sub parse_email {
 		$name = "\"$name\"";
 	}
 
-	return ($name, $address, $comment);
+	return ($name, $name_comment, $address, $comment);
 }
 
 sub format_email {
@@ -1182,6 +1198,23 @@ sub format_email {
 	}
 
 	return $formatted_email;
+}
+
+sub reformat_email {
+	my ($email) = @_;
+
+	my ($email_name, $name_comment, $email_address, $comment) = parse_email($email);
+	return format_email($email_name, $email_address);
+}
+
+sub same_email_addresses {
+	my ($email1, $email2) = @_;
+
+	my ($email1_name, $name1_comment, $email1_address, $comment1) = parse_email($email1);
+	my ($email2_name, $name2_comment, $email2_address, $comment2) = parse_email($email2);
+
+	return $email1_name eq $email2_name &&
+	       $email1_address eq $email2_address;
 }
 
 sub which {
@@ -1217,7 +1250,7 @@ sub expand_tabs {
 		if ($c eq "\t") {
 			$res .= ' ';
 			$n++;
-			for (; ($n % 8) != 0; $n++) {
+			for (; ($n % $tabsize) != 0; $n++) {
 				$res .= ' ';
 			}
 			next;
@@ -1646,8 +1679,16 @@ sub ctx_statement_level {
 sub ctx_locate_comment {
 	my ($first_line, $end_line) = @_;
 
+	# If c99 comment on the current line, or the line before or after
+	my ($current_comment) = ($rawlines[$end_line - 1] =~ m@^\+.*(//.*$)@);
+	return $current_comment if (defined $current_comment);
+	($current_comment) = ($rawlines[$end_line - 2] =~ m@^[\+ ].*(//.*$)@);
+	return $current_comment if (defined $current_comment);
+	($current_comment) = ($rawlines[$end_line] =~ m@^[\+ ].*(//.*$)@);
+	return $current_comment if (defined $current_comment);
+
 	# Catch a comment on the end of the line itself.
-	my ($current_comment) = ($rawlines[$end_line - 1] =~ m@.*(/\*.*\*/)\s*(?:\\\s*)?$@);
+	($current_comment) = ($rawlines[$end_line - 1] =~ m@.*(/\*.*\*/)\s*(?:\\\s*)?$@);
 	return $current_comment if (defined $current_comment);
 
 	# Look through the context and try and figure out if there is a
@@ -2230,7 +2271,7 @@ sub string_find_replace {
 sub tabify {
 	my ($leading) = @_;
 
-	my $source_indent = 8;
+	my $source_indent = $tabsize;
 	my $max_spaces_before_tab = $source_indent - 1;
 	my $spaces_to_tab = " " x $source_indent;
 
@@ -2272,6 +2313,19 @@ sub pos_last_openparen {
 	return length(expand_tabs(substr($line, 0, $last_openparen))) + 1;
 }
 
+sub get_raw_comment {
+	my ($line, $rawline) = @_;
+	my $comment = '';
+
+	for my $i (0 .. (length($line) - 1)) {
+		if (substr($line, $i, 1) eq "$;") {
+			$comment .= substr($rawline, $i, 1);
+		}
+	}
+
+	return $comment;
+}
+
 sub process {
 	my $filename = shift;
 
@@ -2294,6 +2348,7 @@ sub process {
 	my $is_binding_patch = -1;
 	my $in_header_lines = $file ? 0 : 1;
 	my $in_commit_log = 0;		#Scanning lines before patch
+	my $has_patch_separator = 0;	#Found a --- line
 	my $has_commit_log = 0;		#Encountered lines before patch
 	my $commit_log_lines = 0;	#Number of commit log lines
 	my $commit_log_possible_stack_dump = 0;
@@ -2433,6 +2488,7 @@ sub process {
 		$sline =~ s/$;/ /g;	#with comments as spaces
 
 		my $rawline = $rawlines[$linenr - 1];
+		my $raw_comment = get_raw_comment($line, $rawline);
 
 # check if it's a mode change, rename or start of a patch
 		if (!$in_commit_log &&
@@ -2551,7 +2607,7 @@ sub process {
 				if (($last_binding_patch != -1) &&
 				    ($last_binding_patch ^ $is_binding_patch)) {
 					WARN("DT_SPLIT_BINDING_PATCH",
-					     "DT binding docs and includes should be a separate patch. See: Documentation/devicetree/bindings/submitting-patches.txt\n");
+					     "DT binding docs and includes should be a separate patch. See: Documentation/devicetree/bindings/submitting-patches.rst\n");
 				}
 			}
 
@@ -2604,19 +2660,24 @@ sub process {
 			$author = $1;
 			$author = encode("utf8", $author) if ($line =~ /=\?utf-8\?/i);
 			$author =~ s/"//g;
+			$author = reformat_email($author);
 		}
 
 # Check the patch for a signoff:
-		if ($line =~ /^\s*signed-off-by:/i) {
+		if ($line =~ /^\s*signed-off-by:\s*(.*)/i) {
 			$signoff++;
 			$in_commit_log = 0;
 			if ($author ne '') {
-				my $l = $line;
-				$l =~ s/"//g;
-				if ($l =~ /^\s*signed-off-by:\s*\Q$author\E/i) {
-				    $authorsignoff = 1;
+				if (same_email_addresses($1, $author)) {
+					$authorsignoff = 1;
 				}
 			}
+		}
+
+# Check for patch separator
+		if ($line =~ /^---$/) {
+			$has_patch_separator = 1;
+			$in_commit_log = 0;
 		}
 
 # Check if MAINTAINERS is being updated.  If so, there's probably no need to
@@ -2664,7 +2725,7 @@ sub process {
 				}
 			}
 
-			my ($email_name, $email_address, $comment) = parse_email($email);
+			my ($email_name, $name_comment, $email_address, $comment) = parse_email($email);
 			my $suggested_email = format_email(($email_name, $email_address));
 			if ($suggested_email eq "") {
 				ERROR("BAD_SIGN_OFF",
@@ -2675,9 +2736,7 @@ sub process {
 				$dequoted =~ s/" </ </;
 				# Don't force email to have quotes
 				# Allow just an angle bracketed address
-				if ("$dequoted$comment" ne $email &&
-				    "<$email_address>$comment" ne $email &&
-				    "$suggested_email$comment" ne $email) {
+				if (!same_email_addresses($email, $suggested_email)) {
 					WARN("BAD_SIGN_OFF",
 					     "email address '$email' might be better as '$suggested_email$comment'\n" . $herecurr);
 				}
@@ -2720,10 +2779,10 @@ sub process {
 			     "A patch subject line should describe the change not the tool that found it\n" . $herecurr);
 		}
 
-# Check for unwanted Gerrit info
-		if ($in_commit_log && $line =~ /^\s*change-id:/i) {
+# Check for Gerrit Change-Ids not in any patch context
+		if ($realfile eq '' && !$has_patch_separator && $line =~ /^\s*change-id:/i) {
 			ERROR("GERRIT_CHANGE_ID",
-			      "Remove Gerrit Change-Id's before submitting upstream.\n" . $herecurr);
+			      "Remove Gerrit Change-Id's before submitting upstream\n" . $herecurr);
 		}
 
 # Check if the commit log is in a possible stack dump
@@ -2761,7 +2820,7 @@ sub process {
 
 # Check for git id commit length and improperly formed commit descriptions
 		if ($in_commit_log && !$commit_log_possible_stack_dump &&
-		    $line !~ /^\s*(?:Link|Patchwork|http|https|BugLink):/i &&
+		    $line !~ /^\s*(?:Link|Patchwork|http|https|BugLink|base-commit):/i &&
 		    $line !~ /^This reverts commit [0-9a-f]{7,40}/ &&
 		    ($line =~ /\bcommit\s+[0-9a-f]{5,}\b/i ||
 		     ($line =~ /(?:\s|^)[0-9a-f]{12,40}(?:[\s"'\(\[]|$)/i &&
@@ -3014,14 +3073,43 @@ sub process {
 			#print "is_start<$is_start> is_end<$is_end> length<$length>\n";
 		}
 
-# check for MAINTAINERS entries that don't have the right form
-		if ($realfile =~ /^MAINTAINERS$/ &&
-		    $rawline =~ /^\+[A-Z]:/ &&
-		    $rawline !~ /^\+[A-Z]:\t\S/) {
-			if (WARN("MAINTAINERS_STYLE",
-				 "MAINTAINERS entries use one tab after TYPE:\n" . $herecurr) &&
-			    $fix) {
-				$fixed[$fixlinenr] =~ s/^(\+[A-Z]):\s*/$1:\t/;
+# check MAINTAINERS entries
+		if ($realfile =~ /^MAINTAINERS$/) {
+# check MAINTAINERS entries for the right form
+			if ($rawline =~ /^\+[A-Z]:/ &&
+			    $rawline !~ /^\+[A-Z]:\t\S/) {
+				if (WARN("MAINTAINERS_STYLE",
+					 "MAINTAINERS entries use one tab after TYPE:\n" . $herecurr) &&
+				    $fix) {
+					$fixed[$fixlinenr] =~ s/^(\+[A-Z]):\s*/$1:\t/;
+				}
+			}
+# check MAINTAINERS entries for the right ordering too
+			my $preferred_order = 'MRLSWQBCPTFXNK';
+			if ($rawline =~ /^\+[A-Z]:/ &&
+			    $prevrawline =~ /^[\+ ][A-Z]:/) {
+				$rawline =~ /^\+([A-Z]):\s*(.*)/;
+				my $cur = $1;
+				my $curval = $2;
+				$prevrawline =~ /^[\+ ]([A-Z]):\s*(.*)/;
+				my $prev = $1;
+				my $prevval = $2;
+				my $curindex = index($preferred_order, $cur);
+				my $previndex = index($preferred_order, $prev);
+				if ($curindex < 0) {
+					WARN("MAINTAINERS_STYLE",
+					     "Unknown MAINTAINERS entry type: '$cur'\n" . $herecurr);
+				} else {
+					if ($previndex >= 0 && $curindex < $previndex) {
+						WARN("MAINTAINERS_STYLE",
+						     "Misordered MAINTAINERS entry - list '$cur:' before '$prev:'\n" . $hereprev);
+					} elsif ((($prev eq 'F' && $cur eq 'F') ||
+						  ($prev eq 'X' && $cur eq 'X')) &&
+						 ($prevval cmp $curval) > 0) {
+						WARN("MAINTAINERS_STYLE",
+						     "Misordered MAINTAINERS entry - list file patterns in alphabetic order\n" . $hereprev);
+					}
+				}
 			}
 		}
 
@@ -3087,7 +3175,7 @@ sub process {
 					$comment = '/*';
 				} elsif ($realfile =~ /\.(c|dts|dtsi)$/) {
 					$comment = '//';
-				} elsif (($checklicenseline == 2) || $realfile =~ /\.(sh|pl|py|awk|tc)$/) {
+				} elsif (($checklicenseline == 2) || $realfile =~ /\.(sh|pl|py|awk|tc|yaml)$/) {
 					$comment = '#';
 				} elsif ($realfile =~ /\.rst$/) {
 					$comment = '..';
@@ -3110,6 +3198,17 @@ sub process {
 					if (!is_SPDX_License_valid($spdx_license)) {
 						WARN("SPDX_LICENSE_TAG",
 						     "'$spdx_license' is not supported in LICENSES/...\n" . $herecurr);
+					}
+					if ($realfile =~ m@^Documentation/devicetree/bindings/@ &&
+					    not $spdx_license =~ /GPL-2\.0.*BSD-2-Clause/) {
+						my $msg_level = \&WARN;
+						$msg_level = \&CHK if ($file);
+						if (&{$msg_level}("SPDX_LICENSE_TAG",
+
+								  "DT binding documents should be licensed (GPL-2.0-only OR BSD-2-Clause)\n" . $herecurr) &&
+						    $fix) {
+							$fixed[$fixlinenr] =~ s/SPDX-License-Identifier: .*/SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)/;
+						}
 					}
 				}
 			}
@@ -3183,8 +3282,10 @@ sub process {
 
 			if ($msg_type ne "" &&
 			    (show_type("LONG_LINE") || show_type($msg_type))) {
-				WARN($msg_type,
-				     "line over $max_line_length characters\n" . $herecurr);
+				my $msg_level = \&WARN;
+				$msg_level = \&CHK if ($file);
+				&{$msg_level}($msg_type,
+					      "line length of $length exceeds $max_line_length columns\n" . $herecurr);
 			}
 		}
 
@@ -3198,7 +3299,7 @@ sub process {
 		next if ($realfile !~ /\.(h|c|pl|dtsi|dts)$/);
 
 # at the beginning of a line any tabs must come first and anything
-# more than 8 must use tabs.
+# more than $tabsize must use tabs.
 		if ($rawline =~ /^\+\s* \t\s*\S/ ||
 		    $rawline =~ /^\+\s*        \s*/) {
 			my $herevet = "$here\n" . cat_vet($rawline) . "\n";
@@ -3217,7 +3318,7 @@ sub process {
 				"please, no space before tabs\n" . $herevet) &&
 			    $fix) {
 				while ($fixed[$fixlinenr] =~
-					   s/(^\+.*) {8,8}\t/$1\t\t/) {}
+					   s/(^\+.*) {$tabsize,$tabsize}\t/$1\t\t/) {}
 				while ($fixed[$fixlinenr] =~
 					   s/(^\+.*) +\t/$1\t/) {}
 			}
@@ -3239,11 +3340,11 @@ sub process {
 		if ($perl_version_ok &&
 		    $sline =~ /^\+\t+( +)(?:$c90_Keywords\b|\{\s*$|\}\s*(?:else\b|while\b|\s*$)|$Declare\s*$Ident\s*[;=])/) {
 			my $indent = length($1);
-			if ($indent % 8) {
+			if ($indent % $tabsize) {
 				if (WARN("TABSTOP",
 					 "Statements should start on a tabstop\n" . $herecurr) &&
 				    $fix) {
-					$fixed[$fixlinenr] =~ s@(^\+\t+) +@$1 . "\t" x ($indent/8)@e;
+					$fixed[$fixlinenr] =~ s@(^\+\t+) +@$1 . "\t" x ($indent/$tabsize)@e;
 				}
 			}
 		}
@@ -3261,8 +3362,8 @@ sub process {
 				my $newindent = $2;
 
 				my $goodtabindent = $oldindent .
-					"\t" x ($pos / 8) .
-					" "  x ($pos % 8);
+					"\t" x ($pos / $tabsize) .
+					" "  x ($pos % $tabsize);
 				my $goodspaceindent = $oldindent . " "  x $pos;
 
 				if ($newindent ne $goodtabindent &&
@@ -3733,11 +3834,11 @@ sub process {
 			#print "line<$line> prevline<$prevline> indent<$indent> sindent<$sindent> check<$check> continuation<$continuation> s<$s> cond_lines<$cond_lines> stat_real<$stat_real> stat<$stat>\n";
 
 			if ($check && $s ne '' &&
-			    (($sindent % 8) != 0 ||
+			    (($sindent % $tabsize) != 0 ||
 			     ($sindent < $indent) ||
 			     ($sindent == $indent &&
 			      ($s !~ /^\s*(?:\}|\{|else\b)/)) ||
-			     ($sindent > $indent + 8))) {
+			     ($sindent > $indent + $tabsize))) {
 				WARN("SUSPECT_CODE_INDENT",
 				     "suspect code indent for conditional statements ($indent, $sindent)\n" . $herecurr . "$stat_real\n");
 			}
@@ -4014,7 +4115,7 @@ sub process {
 		}
 
 # check for function declarations without arguments like "int foo()"
-		if ($line =~ /(\b$Type\s+$Ident)\s*\(\s*\)/) {
+		if ($line =~ /(\b$Type\s*$Ident)\s*\(\s*\)/) {
 			if (ERROR("FUNCTION_WITHOUT_ARGS",
 				  "Bad function definition - $1() should probably be $1(void)\n" . $herecurr) &&
 			    $fix) {
@@ -4140,6 +4241,17 @@ sub process {
 		if ($line =~ /\bENOSYS\b/) {
 			WARN("ENOSYS",
 			     "ENOSYS means 'invalid syscall nr' and nothing else\n" . $herecurr);
+		}
+
+# ENOTSUPP is not a standard error code and should be avoided in new patches.
+# Folks usually mean EOPNOTSUPP (also called ENOTSUP), when they type ENOTSUPP.
+# Similarly to ENOSYS warning a small number of false positives is expected.
+		if (!$file && $line =~ /\bENOTSUPP\b/) {
+			if (WARN("ENOTSUPP",
+				 "ENOTSUPP is not a SUSV4 error code, prefer EOPNOTSUPP\n" . $herecurr) &&
+			    $fix) {
+				$fixed[$fixlinenr] =~ s/\bENOTSUPP\b/EOPNOTSUPP/;
+			}
 		}
 
 # function brace can't be on same line, except for #defines of do while,
@@ -4582,7 +4694,7 @@ sub process {
 					    ($op eq '>' &&
 					     $ca =~ /<\S+\@\S+$/))
 					{
-					    	$ok = 1;
+						$ok = 1;
 					}
 
 					# for asm volatile statements
@@ -4917,7 +5029,7 @@ sub process {
 			# conditional.
 			substr($s, 0, length($c), '');
 			$s =~ s/\n.*//g;
-			$s =~ s/$;//g; 	# Remove any comments
+			$s =~ s/$;//g;	# Remove any comments
 			if (length($c) && $s !~ /^\s*{?\s*\\*\s*$/ &&
 			    $c !~ /}\s*while\s*/)
 			{
@@ -4956,7 +5068,7 @@ sub process {
 # if and else should not have general statements after it
 		if ($line =~ /^.\s*(?:}\s*)?else\b(.*)/) {
 			my $s = $1;
-			$s =~ s/$;//g; 	# Remove any comments
+			$s =~ s/$;//g;	# Remove any comments
 			if ($s !~ /^\s*(?:\sif|(?:{|)\s*\\?\s*$)/) {
 				ERROR("TRAILING_STATEMENTS",
 				      "trailing statements should be on next line\n" . $herecurr);
@@ -5033,6 +5145,12 @@ sub process {
 			    $var =~ /[A-Z][a-z]|[a-z][A-Z]/ &&
 #Ignore Page<foo> variants
 			    $var !~ /^(?:Clear|Set|TestClear|TestSet|)Page[A-Z]/ &&
+#Ignore printf/scanf format specifiers from inttypes.h like PRIu32, PRIx64 etc.
+			    $var !~ /\bPRI[diux](8|16|32|64)\b/ &&
+			    $var !~ /\bSCN[diux](8|16|32|64)\b/ &&
+			    $var !~ /\bPRI[diuoxX]PTR\b/ &&
+#Ignore EM defined printf format specifiers like PRIxSTAT
+			    $var !~ /\bPRIxSTAT\b/ &&
 #Ignore SI style variants like nS, mV and dB
 #(ie: max_uV, regulator_min_uA_show, RANGE_mA_VALUE)
 			    $var !~ /^(?:[a-z0-9_]*|[A-Z0-9_]*)?_?[a-z][A-Z](?:_[a-z0-9_]+|_[A-Z0-9_]+)?$/ &&
@@ -5132,7 +5250,7 @@ sub process {
 			{
 			}
 
-			# Flatten any obvious string concatentation.
+			# Flatten any obvious string concatenation.
 			while ($dstat =~ s/($String)\s*$Ident/$1/ ||
 			       $dstat =~ s/$Ident\s*($String)/$1/)
 			{
@@ -6230,13 +6348,17 @@ sub process {
 		}
 
 # check for function declarations that have arguments without identifier names
+# while avoiding uninitialized_var(x)
 		if (defined $stat &&
-		    $stat =~ /^.\s*(?:extern\s+)?$Type\s*(?:$Ident|\(\s*\*\s*$Ident\s*\))\s*\(\s*([^{]+)\s*\)\s*;/s &&
-		    $1 ne "void") {
-			my $args = trim($1);
+		    $stat =~ /^.\s*(?:extern\s+)?$Type\s*(?:($Ident)|\(\s*\*\s*$Ident\s*\))\s*\(\s*([^{]+)\s*\)\s*;/s &&
+		    (!defined($1) ||
+		     (defined($1) && $1 ne "uninitialized_var")) &&
+		     $2 ne "void") {
+			my $args = trim($2);
 			while ($args =~ m/\s*($Type\s*(?:$Ident|\(\s*\*\s*$Ident?\s*\)\s*$balanced_parens)?)/g) {
 				my $arg = trim($1);
-				if ($arg =~ /^$Type$/ && $arg !~ /enum\s+$Ident$/) {
+				if ($arg =~ /^$Type$/ &&
+					$arg !~ /enum\s+$Ident$/) {
 					WARN("FUNCTION_ARGUMENTS",
 					     "function definition argument '$arg' should also have an identifier name\n" . $herecurr);
 				}
@@ -6386,6 +6508,28 @@ sub process {
 			if (!$has_break && $has_statement) {
 				WARN("MISSING_BREAK",
 				     "Possible switch case/default not preceded by break or fallthrough comment\n" . $herecurr);
+			}
+		}
+
+# check for /* fallthrough */ like comment, prefer fallthrough;
+		my @fallthroughs = (
+			'fallthrough',
+			'@fallthrough@',
+			'lint -fallthrough[ \t]*',
+			'intentional(?:ly)?[ \t]*fall(?:(?:s | |-)[Tt]|t)hr(?:ough|u|ew)',
+			'(?:else,?\s*)?FALL(?:S | |-)?THR(?:OUGH|U|EW)[ \t.!]*(?:-[^\n\r]*)?',
+			'Fall(?:(?:s | |-)[Tt]|t)hr(?:ough|u|ew)[ \t.!]*(?:-[^\n\r]*)?',
+			'fall(?:s | |-)?thr(?:ough|u|ew)[ \t.!]*(?:-[^\n\r]*)?',
+		    );
+		if ($raw_comment ne '') {
+			foreach my $ft (@fallthroughs) {
+				if ($raw_comment =~ /$ft/) {
+					my $msg_level = \&WARN;
+					$msg_level = \&CHK if ($file);
+					&{$msg_level}("PREFER_FALLTHROUGH",
+						      "Prefer 'fallthrough;' over fallthrough comment\n" . $herecurr);
+					last;
+				}
 			}
 		}
 

--- a/scripts/em_odp_check
+++ b/scripts/em_odp_check
@@ -11,7 +11,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 IGNORE='NEW_TYPEDEFS,'
 IGNORE+='COMPARISON_TO_NULL,'
 IGNORE+='PREFER_KERNEL_TYPES,'
-IGNORE+='CAMELCASE,' #Suppress warning from PRIu64
 IGNORE+='MACRO_WITH_FLOW_CONTROL,'
 IGNORE+='LONG_LINE_STRING,'
 IGNORE+='PREFER_PRINTF,'
@@ -19,7 +18,8 @@ IGNORE+='CONST_STRUCT,'
 IGNORE+='FUNCTION_ARGUMENTS,'
 IGNORE+='MACRO_ARG_REUSE,'
 IGNORE+='SPDX_LICENSE_TAG,'
-IGNORE+='C99_COMMENT_TOLERANCE' # C99-style comments '//' reported as error
+IGNORE+='C99_COMMENT_TOLERANCE,' # C99-style comments '//' reported as error
+IGNORE+='PREFER_FALLTHROUGH'
 
 $DIR/cleanfile $1 2> /dev/null
 $DIR/checkpatch.pl -f --no-tree --ignore $IGNORE --mailback --strict --terse --no-summary --show-types $1 2> /dev/null

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,8 +11,8 @@ AM_CFLAGS += -I$(top_srcdir)/include/event_machine/add-ons
 AM_CFLAGS += -I$(top_srcdir)/src/misc
 
 AM_CFLAGS += $(ODP_CFLAGS)
-
-AM_CFLAGS +=  $(LIBCONFIG_CFLAGS)
+AM_CFLAGS += $(LIBCONFIG_CFLAGS)
+AM_CFLAGS += $(VISIBILITY_CFLAGS) # -fvisibility=hidden set if supported
 
 AM_LDFLAGS += -version-number '$(EMODP_LIBSO_VERSION)'
 
@@ -103,6 +103,7 @@ em_pool.c \
 em_queue.c \
 em_queue_group.c \
 em_libconfig.c \
+em_init.c \
 	\
 env/env_sharedmem.c \
 misc/objpool.c \

--- a/src/em_atomic_group.c
+++ b/src/em_atomic_group.c
@@ -218,7 +218,7 @@ atomic_group_dispatch(em_event_t ev_tbl[], event_hdr_t *const ev_hdr_tbl[],
 	enq_cnt = ag_internal_enq(ag_elem, ev_tbl, num_events, priority);
 
 	if (unlikely(enq_cnt < num_events)) {
-		event_free_multi(&ev_tbl[enq_cnt], num_events - enq_cnt);
+		em_free_multi(&ev_tbl[enq_cnt], num_events - enq_cnt);
 		/*
 		 * Use dispatch escope since this func is called only from
 		 * dispatch_round() => atomic_group_dispatch()
@@ -277,8 +277,9 @@ atomic_group_dispatch(em_event_t ev_tbl[], event_hdr_t *const ev_hdr_tbl[],
 				batch_cnt++;
 			}
 
-			dispatch_events(&deq_hdr_tbl[tbl_idx], batch_cnt,
-					batch_qelem);
+			dispatch_events(&deq_ev_tbl[tbl_idx],
+					&deq_hdr_tbl[tbl_idx],
+					batch_cnt, batch_qelem);
 			tbl_idx += batch_cnt;
 		} while (tbl_idx < deq_cnt);
 

--- a/src/em_chaining.h
+++ b/src/em_chaining.h
@@ -40,20 +40,23 @@
 extern "C" {
 #endif
 
+#pragma GCC visibility push(default)
 /**
  * This function is declared as a weak symbol, indicating that the user should
  * override it during linking with another implementation if event chaining is
  * used.
  */
-em_status_t __attribute__((weak))
-event_send_device(em_event_t event, em_queue_t queue);
+__attribute__((weak))
+em_status_t event_send_device(em_event_t event, em_queue_t queue);
 /**
  * This function is declared as a weak symbol, indicating that the user should
  * override it during linking with another implementation if event chaining is
  * used.
  */
-int __attribute__((weak))
-event_send_device_multi(em_event_t *const events, int num, em_queue_t queue);
+__attribute__((weak))
+int event_send_device_multi(em_event_t *const events, int num,
+			    em_queue_t queue);
+#pragma GCC visibility pop
 
 /**
  * Initialize event chaining during start-up

--- a/src/em_core.c
+++ b/src/em_core.c
@@ -112,7 +112,7 @@ logic_to_thr_core_id(const int logic_core)
 int
 thr_to_logic_core_id(const int thr_id)
 {
-	if (unlikely(thr_id >= EM_MAX_CORES))
+	if (unlikely(thr_id >= ODP_THREAD_COUNT_MAX))
 		return -1;
 
 	return em_shm->core_map.thr_vs_logic.logic[thr_id];

--- a/src/em_eo.c
+++ b/src/em_eo.c
@@ -158,7 +158,11 @@ eo_add_queue(eo_elem_t *const eo_elem, queue_elem_t *const q_elem)
 	if (unlikely(err != EM_OK))
 		return err;
 
+	q_elem->use_multi_rcv = eo_elem->use_multi_rcv;
+	q_elem->max_events = eo_elem->max_events;
 	q_elem->receive_func = eo_elem->receive_func;
+	q_elem->receive_multi_func = eo_elem->receive_multi_func;
+
 	q_elem->eo = eo_elem->eo;
 	q_elem->eo_ctx = eo_elem->eo_ctx;
 	q_elem->eo_elem = eo_elem;

--- a/src/em_eo_types.h
+++ b/src/em_eo_types.h
@@ -57,8 +57,14 @@ typedef struct {
 	em_stop_func_t stop_func;
 	/** EO core-local stop function */
 	em_stop_local_func_t stop_local_func;
+
+	int use_multi_rcv; /* true:receive_multi_func(), false:receive_func() */
+	int max_events;
 	/** EO event receive function */
 	em_receive_func_t receive_func;
+	/** EO multi-event receive function */
+	em_receive_multi_func_t receive_multi_func;
+
 	/** EO specific error handler function */
 	em_error_handler_t error_handler_func;
 	/** EO context data pointer */

--- a/src/em_hooks.c
+++ b/src/em_hooks.c
@@ -73,7 +73,7 @@ hooks_init(em_api_hooks_t *const api_hooks)
 	em_shm->send_hook_storage.idx = 0;
 
 	env_spinlock_init(&em_shm->dispatch_enter_cb_storage.lock);
-	env_spinlock_init(&em_shm->dispatch_enter_cb_storage.lock);
+	env_spinlock_init(&em_shm->dispatch_exit_cb_storage.lock);
 	env_spinlock_init(&em_shm->alloc_hook_storage.lock);
 	env_spinlock_init(&em_shm->free_hook_storage.lock);
 	env_spinlock_init(&em_shm->send_hook_storage.lock);
@@ -108,7 +108,7 @@ hook_register(uint8_t hook_type, hook_fn_t hook_fn)
 	hook_tbl_t **active_tbl_ptr;
 
 	/* Get the em_shm hook table and hook storage to update */
-	active_tbl_ptr = get_hook_tbl(hook_type, &hook_storage);
+	active_tbl_ptr = get_hook_tbl(hook_type, &hook_storage/*out*/);
 	if (unlikely(active_tbl_ptr == NULL))
 		return EM_ERR_BAD_ID;
 
@@ -160,7 +160,7 @@ hook_unregister(uint8_t hook_type, hook_fn_t hook_fn)
 	hook_tbl_t *hook_tbl, *next_tbl;
 	hook_tbl_t **active_tbl_ptr;
 
-	active_tbl_ptr = get_hook_tbl(hook_type, &hook_storage);
+	active_tbl_ptr = get_hook_tbl(hook_type, &hook_storage/*out*/);
 	if (unlikely(active_tbl_ptr == NULL))
 		return EM_ERR_BAD_ID;
 

--- a/src/em_hooks.h
+++ b/src/em_hooks.h
@@ -62,64 +62,38 @@ hook_register(uint8_t type, hook_fn_t hook_fn);
 em_status_t
 hook_unregister(uint8_t type, hook_fn_t hook_fn);
 
-/**
- *
- * Note: All callbacks are run even if the event is freed (=EM_EVENT_UNDEF).
- */
 static inline void
-call_api_hooks_alloc(em_event_t event, size_t size,
-		     em_event_type_t type, em_pool_t pool)
+call_api_hooks_alloc(const em_event_t events[], const int num_act,
+		     const int num_req, size_t size, em_event_type_t type,
+		     em_pool_t pool)
 {
 	hook_tbl_t *const alloc_hook_tbl = em_shm->alloc_hook_tbl;
 	em_api_hook_alloc_t alloc_hook_fn;
-	int i;
 
-	for (i = 0; i < EM_CALLBACKS_MAX; i++) {
+	for (int i = 0; i < EM_CALLBACKS_MAX; i++) {
 		alloc_hook_fn = alloc_hook_tbl->tbl[i].alloc;
 		if (alloc_hook_fn == NULL)
 			return;
-		alloc_hook_fn(event, size, type, pool);
+		alloc_hook_fn(events, num_act, num_req, size, type, pool);
 	}
 }
 
 static inline void
-call_api_hooks_free(em_event_t event)
+call_api_hooks_free(const em_event_t events[], const int num)
 {
 	hook_tbl_t *const free_hook_tbl = em_shm->free_hook_tbl;
 	em_api_hook_free_t free_hook_fn;
-	int i;
 
-	for (i = 0; i < EM_CALLBACKS_MAX; i++) {
+	for (int i = 0; i < EM_CALLBACKS_MAX; i++) {
 		free_hook_fn = free_hook_tbl->tbl[i].free;
 		if (free_hook_fn == NULL)
 			return;
-		free_hook_fn(event);
+		free_hook_fn(events, num);
 	}
 }
 
 static inline void
-call_api_hooks_free_multi(em_event_t *const events, const int num)
-{
-	hook_tbl_t *const free_hook_tbl = em_shm->free_hook_tbl;
-
-	if (free_hook_tbl->tbl[0].free == NULL)
-		return;
-
-	em_api_hook_free_t free_hook_fn;
-	int i, j;
-
-	for (i = 0; i < num; i++) {
-		for (j = 0; j < EM_CALLBACKS_MAX; j++) {
-			free_hook_fn = free_hook_tbl->tbl[j].free;
-			if (free_hook_fn == NULL)
-				return;
-			free_hook_fn(events[i]);
-		}
-	}
-}
-
-static inline void
-call_api_hooks_send(em_event_t *const events, int num,
+call_api_hooks_send(const em_event_t events[], const int num,
 		    em_queue_t queue, em_event_group_t event_group)
 {
 	hook_tbl_t *const send_hook_tbl = em_shm->send_hook_tbl;

--- a/src/em_init.c
+++ b/src/em_init.c
@@ -1,0 +1,73 @@
+/* Copyright (c) 2020 Nokia Solutions and Networks
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:	BSD-3-Clause
+ */
+
+#include "em_include.h"
+
+em_status_t
+poll_drain_mask_check(em_core_mask_t *const logic_mask,
+		      em_core_mask_t *const poll_drain_mask)
+{
+	/* check if mask is zero (all cores, OK) */
+	if (em_core_mask_iszero(poll_drain_mask))
+		return EM_OK;
+
+	int i;
+
+	/* check mask validity */
+	for (i = 0; i < EM_MAX_CORES; i++) {
+		if (em_core_mask_isset(i, poll_drain_mask) &&
+		    !em_core_mask_isset(i, logic_mask))
+			return EM_ERR_OPERATION_FAILED;
+	}
+	return EM_OK;
+}
+
+em_status_t
+input_poll_init(em_core_mask_t *const logic_mask, em_conf_t *const conf)
+{
+	return poll_drain_mask_check(logic_mask,
+				     &conf->input.input_poll_mask);
+}
+
+em_status_t
+output_drain_init(em_core_mask_t *const logic_mask, em_conf_t *const conf)
+{
+	return poll_drain_mask_check(logic_mask,
+				     &conf->output.output_drain_mask);
+}
+
+em_status_t
+poll_drain_mask_set_local(int *const result, int core_id,
+			  em_core_mask_t *const mask)
+{
+	if (em_core_mask_iszero(mask) || em_core_mask_isset(core_id, mask))
+		*result = EM_TRUE;
+	else
+		*result = EM_FALSE;
+	return EM_OK;
+}
+
+em_status_t
+input_poll_init_local(int *const result, int core_id, em_conf_t *const conf)
+{
+	if (conf->input.input_poll_fn == NULL) {
+		*result = EM_FALSE;
+		return EM_OK;
+	}
+	return poll_drain_mask_set_local(result, core_id,
+					 &conf->input.input_poll_mask);
+}
+
+em_status_t
+output_drain_init_local(int *const result, int core_id, em_conf_t *const conf)
+{
+	if (conf->output.output_drain_fn == NULL) {
+		*result = EM_FALSE;
+		return EM_OK;
+	}
+	return poll_drain_mask_set_local(result, core_id,
+					 &conf->output.output_drain_mask);
+}

--- a/src/em_init.h
+++ b/src/em_init.h
@@ -73,6 +73,25 @@ typedef struct {
 	} event_chaining;
 } opt_t;
 
+em_status_t
+poll_drain_mask_check(em_core_mask_t *const logic_mask,
+		      em_core_mask_t *const poll_drain_mask);
+
+em_status_t
+input_poll_init(em_core_mask_t *const logic_mask, em_conf_t *const conf);
+
+em_status_t
+output_drain_init(em_core_mask_t *const logic_mask, em_conf_t *const conf);
+
+em_status_t
+poll_drain_mask_set_local(int *result, int core_id, em_core_mask_t *const mask);
+
+em_status_t
+input_poll_init_local(int *result, int core_id, em_conf_t *const conf);
+
+em_status_t
+output_drain_init_local(int *result, int core_id, em_conf_t *const conf);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/em_mem.h
+++ b/src/em_mem.h
@@ -93,34 +93,40 @@ typedef struct {
 	event_group_pool_t event_group_pool ENV_CACHE_LINE_ALIGNED;
 	/** Error handler structure */
 	error_handler_t error_handler ENV_CACHE_LINE_ALIGNED;
-	/** Dispatcher enter callback functions currently in use */
+
+	/**
+	 * Dispatcher enter callback functions currently in use,
+	 * called for EO's using a single-event receive function.
+	 */
 	hook_tbl_t *dispatch_enter_cb_tbl ENV_CACHE_LINE_ALIGNED;
+	/** Dispatcher exit callback functions currently in use */
+	hook_tbl_t *dispatch_exit_cb_tbl;
+	/** Alloc-hook functions currently in use */
+	hook_tbl_t *alloc_hook_tbl;
+	/** Free-hook functions currently in use */
+	hook_tbl_t *free_hook_tbl;
+	/** Send-hook functions currently in use */
+	hook_tbl_t *send_hook_tbl;
+
 	/** Dispatch enter callback storage, many sets of callback-tables */
 	hook_storage_t dispatch_enter_cb_storage ENV_CACHE_LINE_ALIGNED;
-	/** Dispatcher exit callback functions currently in use */
-	hook_tbl_t *dispatch_exit_cb_tbl ENV_CACHE_LINE_ALIGNED;
 	/** Dispatch exit callback storage, many sets of callback-tables */
 	hook_storage_t dispatch_exit_cb_storage ENV_CACHE_LINE_ALIGNED;
-	/** Alloc-hook functions currently in use */
-	hook_tbl_t *alloc_hook_tbl ENV_CACHE_LINE_ALIGNED;
 	/** Alloc-hook function storage, many sets of hook-tables */
 	hook_storage_t alloc_hook_storage ENV_CACHE_LINE_ALIGNED;
-	/** Free-hook functions currently in use */
-	hook_tbl_t *free_hook_tbl ENV_CACHE_LINE_ALIGNED;
 	/** Free-hook function storage, many sets of hook-tables */
 	hook_storage_t free_hook_storage ENV_CACHE_LINE_ALIGNED;
-	/** Send-hook functions currently in use */
-	hook_tbl_t *send_hook_tbl ENV_CACHE_LINE_ALIGNED;
 	/** Send-hook function storage, many sets of hook-tables */
 	hook_storage_t send_hook_storage ENV_CACHE_LINE_ALIGNED;
+
 	/** Synchronous API locks */
 	sync_api_t sync_api ENV_CACHE_LINE_ALIGNED;
 	/** Current number of allocated EOs */
 	env_atomic32_t eo_count ENV_CACHE_LINE_ALIGNED;
-	/** Daemon eo */
-	daemon_eo_t daemon ENV_CACHE_LINE_ALIGNED;
 	/** Timer resources */
 	timer_storage_t timers ENV_CACHE_LINE_ALIGNED;
+	/** Daemon eo */
+	daemon_eo_t daemon ENV_CACHE_LINE_ALIGNED;
 	/** Current number of allocated queues */
 	env_atomic32_t queue_count;
 	/** Current number of allocated queue groups */
@@ -155,6 +161,8 @@ typedef struct {
 		em_event_group_t egrp;
 		/** Current event group generation count*/
 		int32_t egrp_gen;
+		/** EO-receive function burst count */
+		int rcv_multi_cnt;
 		/** Current scheduling context type */
 		em_sched_context_type_t sched_context_type;
 	} current;
@@ -176,6 +184,11 @@ typedef struct {
 	eo_elem_t *start_eo_elem;
 	/** The number of errors on a core */
 	uint64_t error_count;
+
+	/** Is input_poll_fn executed on this core */
+	int do_input_poll;
+	/** Is output_drain_fn executed on this core */
+	int do_output_drain;
 
 	/** Guarantee that size is a multiple of cache line size */
 	void *end[0] ENV_CACHE_LINE_ALIGNED;

--- a/src/em_pool.h
+++ b/src/em_pool.h
@@ -41,6 +41,11 @@
 extern "C" {
 #endif
 
+#define valid_pool(pool)   ((unsigned int)pool_hdl2idx((pool)) < \
+			    EM_CONFIG_POOLS)
+#define invalid_pool(pool) ((unsigned int)pool_hdl2idx((pool)) > \
+			    EM_CONFIG_POOLS - 1)
+
 em_status_t
 pool_init(mpool_tbl_t *const mpool_tbl, mpool_pool_t *const mpool_pool,
 	  em_pool_cfg_t *const default_pool_cfg);
@@ -117,23 +122,23 @@ unsigned int
 pool_count(void);
 
 static inline void
-pool_stat_increment(em_pool_t pool, int subpool)
+pool_stat_increment(em_pool_t pool, int subpool, uint64_t cnt)
 {
 	const int pool_idx = pool_hdl2idx(pool);
 	mpool_statistics_t *const pstat =
 		&em_shm->mpool_tbl.pool_stat_core[em_core_id()];
 
-	pstat->stat[pool_idx][subpool].alloc++;
+	pstat->stat[pool_idx][subpool].alloc += cnt;
 }
 
 static inline void
-pool_stat_decrement(em_pool_t pool, int subpool)
+pool_stat_decrement(em_pool_t pool, int subpool, uint64_t cnt)
 {
 	const int pool_idx = pool_hdl2idx(pool);
 	mpool_statistics_t *const pstat =
 		&em_shm->mpool_tbl.pool_stat_core[em_core_id()];
 
-	pstat->stat[pool_idx][subpool].free++;
+	pstat->stat[pool_idx][subpool].free += cnt;
 }
 
 void

--- a/src/em_queue_types.h
+++ b/src/em_queue_types.h
@@ -187,8 +187,13 @@ typedef struct queue_elem_t {
 	eo_elem_t *eo_elem;
 	/** Copy of the user defined eo context (or NULL) for performance */
 	void *eo_ctx;
-	/** Copy of the receive function for better performance */
+
+	int use_multi_rcv; /* true:receive_multi_func(), false:receive_func() */
+	int max_events;
+	/** Copy of the event receive function for better performance */
 	em_receive_func_t receive_func;
+	/** Copy of the multi-event receive function for better performance */
+	em_receive_multi_func_t receive_multi_func;
 
 	union {
 		q_elem_atomic_group_t agrp;

--- a/src/event_machine_dispatcher.c
+++ b/src/event_machine_dispatcher.c
@@ -47,10 +47,10 @@ em_dispatch(uint64_t rounds)
 	odp_schedule_resume();
 
 	if (likely(rounds > 0)) {
-		if (input_poll || output_drain) {
+		if (em_locm.do_input_poll || em_locm.do_output_drain) {
 			for (i = 0; i < rounds;) {
 				dispatched_events = 0;
-				if (input_poll)
+				if (em_locm.do_input_poll)
 					rx_events = input_poll();
 				do {
 					num = dispatch_round();
@@ -59,7 +59,7 @@ em_dispatch(uint64_t rounds)
 				} while (dispatched_events < rx_events &&
 					 num > 0 && i < rounds);
 				events += dispatched_events; /* inc ret value*/
-				if (output_drain)
+				if (em_locm.do_output_drain)
 					(void)output_drain();
 			}
 		} else {
@@ -76,17 +76,17 @@ em_dispatch(uint64_t rounds)
 		} while (num > 0);
 	} else {
 		/* rounds == 0 (== FOREVER) */
-		if (input_poll || output_drain) {
+		if (em_locm.do_input_poll || em_locm.do_output_drain) {
 			for (;/*ever*/;) {
 				dispatched_events = 0;
-				if (input_poll)
+				if (em_locm.do_input_poll)
 					rx_events = input_poll();
 				do {
 					num = dispatch_round();
 					dispatched_events += num;
 				} while (dispatched_events < rx_events &&
 					 num > 0);
-				if (output_drain)
+				if (em_locm.do_output_drain)
 					(void)output_drain();
 			}
 		} else {


### PR DESCRIPTION
- Support for EM API v2.3 (em-odp/include), see API changes in
  em-odp/include/event_machine/README_API:
    - Event: multi-event alloc and free functions
    - Hooks: use the same hook-type for all allocs and the same for all frees
    - EO: multi-event EO-receive function
    - Dispatch: one common enter-callback for multi- and single-receive funcs.
    - Init: core masks for input_poll_fn and output_drain_fn added to em_conf_t
    - Init: use em_conf_init(em_conf_t *conf) to init the EM config params.
    - Event: APIs to get the event type(s) of multiple events
- Fix libemodp symbol visibility, only expose API symbols
- New example program:     timer_test_periodic
  New packet-io programs:  loopback_local_multircv, loopback_multircv
  New performance program: loop_multircv