### PR TITLE
ci: github build: configure with "--enable-check-level=3 --enable-esv"

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,7 +23,9 @@ pushd ${BUILD_DIR}/../..
 ./bootstrap
 ./configure \
 	--prefix=${BUILD_DIR}/em-odp_install \
-	--with-odp-path=${BUILD_DIR}/odp_install
+	--with-odp-path=${BUILD_DIR}/odp_install \
+	--enable-check-level=3 \
+	--enable-esv
 make -j $(nproc)
 make install
 popd


### PR DESCRIPTION
Add the following configure-options to the em-odp CI build script:

--enable-check-level=3:
enables EM to do more thorough runtime error checking

--enable-esv:
enables Event State Verification (ESV), a feature that during runtime
checks that the state of each event is valid to prevent double-free,
double-send, use-after-send, use after-free etc.

Adding these options has a slight negative effect on performance.