### PR TITLE
em-odp v2.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ build*/
 debug*/
 doc/html/
 .vscode
+*.code-workspace

--- a/CHANGE_NOTES
+++ b/CHANGE_NOTES
@@ -27,7 +27,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ===============================================================================
-CHANGE NOTES - Event Machine on ODP (em-odp)
+CHANGE NOTES - Event Machine (EM) on ODP (em-odp)
 ===============================================================================
 
 The version numbering scheme reflects the used EM API version:
@@ -42,6 +42,121 @@ The version numbering scheme reflects the used EM API version:
 
 - See em-odp/README for usage and compilation instructions.
 - See em-odp/include/event_machine/README_API for API changes
+
+--------------------------------------------------------------------------------
+Event Machine (EM) on ODP v2.6.0
+--------------------------------------------------------------------------------
+- Support for EM API v2.6 (em-odp/include), see API changes in
+  em-odp/include/event_machine/README_API.
+  * New APIs for Timer, Event, Queue, Extension-APIs *
+
+- New configure script option (see em-odp/configure.ac):
+  '--enable-debug-print' that enables EM debug printouts via the EM_DBG() macro:
+        em-odp/build $> ../configure --prefix=… --enable-debug-print
+  Currently if enabled, will print event header layout information at startup
+  as well as EM timer runtime debug info.
+
+- EM config file options - config/em-odp.conf:
+ - Config file version bumped to "0.0.9" (user config files need to be updated!)
+ - Options for setting EM Queue priority-levels:
+   a) Option 'queue.priority.map_mode':
+     Select the queue priority mapping mode, i.e how to map EM queue priorities
+     to ODP scheduled queue priorities.
+     0: legacy simple mode, map EM prios to ODP min/default/max prio-levels only
+        (0 is the default mode)
+     1: map according to the ODP runtime number of priorities
+        (linear fit to full range of ODP prio-levels)
+     2: custom mapping
+        (use 'custom_map' below)
+   b) Option 'queue.priority.custom_map':
+     Custom priority map (required when 'queue.priority.map_mode = 2')
+     This array needs to have EM_QUEUE_PRIO_NUM entries (typically 8).
+     The first entry is for the lowest priority (0). The value is ADDED to
+     odp_schedule_min_prio() and then passed to ODP, i.e. values are offsets
+     from odp_schedule_min_prio(). Values given here must be valid for ODP
+     runtime configuration, i.e. value plus odp_schedule_min_prio() must
+     not exceed odp_schedule_max_prio().
+     Example of a custom priority mapping:
+        queue: {
+                priority: {
+                        map_mode = 2
+                        custom_map = [0, 0, 1, 3 ,4 ,6 ,7, 7]
+                }
+        }
+
+- EM SW ISA printout added at start-up:
+    ...
+    ===========================================================
+    EM Info on target: em-odp
+    ===========================================================
+    EM API version:         v2.6, 64 bit (EM_CHECK_LEVEL:3, EM_ESV_ENABLE:1)
+    EM build info:          v2.6.0 2021-10-15 16:46
+    ODP API version:        1.32.0
+    ODP impl name:          odp-linux
+    ODP impl details:       odp-linux 1.32.0-0 (v1.32.0) 1.32.0.0
+    CPU model:              Intel(R) Xeon(R) CPU E5-2697 v3
+    CPU arch:               x86     // ARM etc.
+    CPU ISA version:        Unknown // ARMv8.2-A  # HW detected, reported by ODP
+     SW ISA version (ODP):  x86_64  // ARMv8.1-A  # ODP SW config (compile time)
+     SW ISA version (EM):   x86_64  // ARMv8.1-A  #  EM SW config (compile time)
+
+  Arch specific CFLAGS should be passed to EM and ODP via configure.
+  Example for a made up ARMv8 SoC called "soc-x":
+  odp-soc-x/build> ../configure … --with-platform=soc-x [default=linux-generic]
+     em-odp/build> ../configure … CFLAGS=”-march=armv8.2-a+… -mcpu=soc-x”
+  The whole chain of used SW libs/dependencies should preferably be compiled
+  with the same -march/-mcpu options for best results:
+    other-libs/build> ../configure … CFLAGS=”-march=armv8.2-a+… -mcpu=soc-x”
+
+- Program termination: flush the scheduler in em_term_core() on each EM-core.
+  Move the flushing of scheduled events from em_term() to em_term_core() so that
+  all participating EM-cores do it.
+  See example usage of in em-odp/programs/common/cm_setup.c:
+  ('thread' in the description below refers to odph_thread_t that can be either
+   linux processes or threads)
+  em_term() has been moved from each EM-core's run-function to the common thread
+  that created the EM-core threads. The common thread waits for the created
+  EM-core threads to return/join.
+  After each EM-core has paused and flushed the scheduler from core-local events
+  (by calling em_term_local()) they terminate by "joining" back into the common
+  thread, which calls em_term() once to terminate EM (and ODP) before exiting
+  the application.
+
+- Fixes:
+  - queue group: fix: em_queue_group_modify_sync() incorrectly removed the
+                      calling core
+  - ESV: fix: usr2em-revert transition to handle evgen wrap correctly
+    Event State Verification (ESV) incorrectly handled the revert of a usr-to-EM
+    transition when the counter wrapped.
+
+- Example programs (em-odp/programs)
+  - Common Setup (cm_setup.c&h):
+    - Move the flushing of scheduled events from em_term() to em_term_core().
+      Descibed above in "Program termination".
+  - Packet-IO setup (cm_pktio.c&h)
+    - Add command-line option to select whether to use an
+      1) ODP-packet-pool: -o, --pktpool-odp
+         or an
+      2) EM event-pool: -e, --pktpool-em (default if no option given)
+      as the main event pool to be used by packet-io for received packets.
+      Packet-IO is implemented via ODP so an EM event-pool needs to be converted
+      to the corresponding ODP packet-pools with the new extension API
+      'em_odp_pool2odp()'. Using an EM pool, instead of directly using an
+      ODP pool, allows for more thorough ESV-checking also for packet-IO when
+      em-odp.conf: esv.prealloc_pools = true.
+  - Timer
+  - Misc. performance and bug fixes in the example applications
+
+- Tested against
+  odp-linux - https://github.com/OpenDataPlane/odp
+    Commit: 69f27643ec2287875048314d7975f0de4bcbbfa4 [69f2764]
+    Date: Friday, 1 October 2021 18:12.09
+    Commit Date: Tuesday, 12 October 2021 17:06.16
+    configure.ac: move project to C standard revision 11
+  odp-dpdk - https://github.com/OpenDataPlane/odp-dpdk
+    Commit: 50c7b605b97474d26fcf600b4061968e3543b45b [50c7b60]
+    Date: Monday, 11 October 2021 16:37.51
+    Merge ODP v1.32.0.0
 
 --------------------------------------------------------------------------------
 Event Machine on ODP v2.5.0

--- a/README
+++ b/README
@@ -57,16 +57,6 @@ development.
 See further configure options: ../configure --help
 > make && make install
 
-Tested against
-odp-linux - https://github.com/OpenDataPlane/odp
-  Commit: edf40d0470a6dd911170775e8185a5458914a372 [edf40d0]
-  Date: Wednesday, 21 April 2021 17:02.09
-  linux-gen: ipsec: add event type assertion in odp_ipsec_packet_from_event()
-odp-dpdk - https://github.com/OpenDataPlane/odp-dpdk
-  Commit: c3e252739b6c5812d11ac07ec7df687d927de36e [c3e2527]
-  Date: Tuesday, 20 April 2021 9:39.16
-  github_ci: test process mode operation
-
 Clone EM-ODP code:
 > git clone <em-odp repo>
 Here <em-odp repo> can be e.g. https://github.com/openeventmachine/em-odp.git.

--- a/config/em-odp.conf
+++ b/config/em-odp.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 em_implementation = "em-odp"
-config_file_version = "0.0.8"
+config_file_version = "0.0.9"
 
 # Pool options
 pool: {
@@ -62,7 +62,7 @@ pool: {
 	#                base (min 32B aligned, power-of-two)
 	align_offset = 0
 
- 	# Default minimum packet headroom in bytes for events allocated from
+	# Default minimum packet headroom in bytes for events allocated from
 	# EM-pools of type: EM_EVENT_TYPE_PACKET. Ignored for other pool types.
 	#
 	# This is a global setting for EM-pools of type EM_EVENT_TYPE_PACKET.
@@ -96,6 +96,31 @@ queue: {
 	# Setting 'min_events_default = 0' will use the odp-implementation's
 	# default values (might vary from one odp-implementation to another).
 	min_events_default = 4096
+
+	priority: {
+		# Select the priority mapping mode (EM API to ODP)
+		#
+		#  0: legacy simple mode, map EM to ODP min/default/max only
+		#     (0 is default if entry is missing)
+		#  1: map according to odp runtime number of priorities
+		#     (linear fit to full range of odp)
+		#  2: custom map
+		#     (use custom_map below)
+		#
+		map_mode = 0
+
+		# Custom priority map (required when map_mode = 2)
+		#
+		# This array needs to have EM_QUEUE_PRIO_NUM entries
+		# (typically 8). First entry is for lowest priority (0).
+		# The value is ADDED to odp_schedule_min_prio() and then passed
+		# to ODP, i.e. values are offsets from odp_schedule_min_prio.
+		# Values given here must be valid for odp runtime configuration,
+		# i.e. value plus odp_schedule_min_prio() must not exceed
+		# odp_schedule_max_prio().
+		#
+		#custom_map = [0, 0, 1, 3 ,4 ,6 ,7, 7]
+	}
 }
 
 # Event-Chaining options

--- a/configure.ac
+++ b/configure.ac
@@ -3,30 +3,37 @@ AC_PREREQ([2.69])
 # Version
 ############################
 m4_define([em_api_major_version], [2])
-m4_define([em_api_minor_version], [5])
+m4_define([em_api_minor_version], [6])
 m4_define([em_api_implementation_version], [0])
 m4_define([em_api_implementation_fix], [0])
 
 m4_define([em_api_version], [em_api_major_version.em_api_minor_version])
 m4_define([em_version], [m4_if(m4_eval(em_api_implementation_fix), [0],
 	  [em_api_major_version.em_api_minor_version.em_api_implementation_version],
-	  [em_api_major_version.em_api_minor_version.em_api_implementation_version-em_api_implementation_fix])])
+	  [em_api_major_version.em_api_minor_version.\
+em_api_implementation_version-em_api_implementation_fix])])
 
-m4_define([em_lib_version], m4_join([], em_api_major_version, em_api_minor_version))
+m4_define([em_lib_version],
+	  m4_join([], em_api_major_version, em_api_minor_version))
+
 m4_if(em_api_implementation_fix, [0],
       [m4_append([em_lib_version],
 		 m4_combine([], [[]], [:], em_api_implementation_version, [0]))],
       [m4_append([em_lib_version],
-		 m4_combine([], [[]], [:], em_api_implementation_version, em_api_implementation_fix))])
+		 m4_combine([], [[]], [:], em_api_implementation_version,
+		 em_api_implementation_fix))])
 
-m4_define([em_pkgconfig_version], m4_join([], em_api_major_version, em_api_minor_version))
+m4_define([em_pkgconfig_version],
+	  m4_join([], em_api_major_version, em_api_minor_version))
+
 m4_if(em_api_implementation_fix, [0],
       [m4_append([em_pkgconfig_version],
 		 m4_combine([], [[]], [.], em_api_implementation_version, [0]))],
       [m4_append([em_pkgconfig_version],
-		 m4_combine([], [[]], [.], em_api_implementation_version, em_api_implementation_fix))])
+		 m4_combine([], [[]], [.], em_api_implementation_version,
+		 em_api_implementation_fix))])
 
-AC_INIT([EM-ODP],[em_version],[foo at nokia.com])
+AC_INIT([EM-ODP],[em_version],[EM at nokia.com])
 
 EM_API_MAJOR_VERSION=em_api_major_version
 AC_SUBST([EM_API_MAJOR_VERSION])
@@ -246,6 +253,29 @@ AC_ARG_ENABLE([esv],
 	      ],[])
 # Substitute @EM_ESV_ENABLE@ into the pkgconfig file libemodp.pc.in
 AC_SUBST([EM_ESV_ENABLE])
+
+##########################################################################
+# Enable/disable EM_DEBUG_PRINT
+##########################################################################
+debug_print_info="no (EM_DEBUG_PRINT from source code)"
+AC_ARG_ENABLE([debug-print],
+	      [AS_HELP_STRING([--enable-debug-print],
+			      [Display debugging information [default=disabled]])],
+	      [AS_IF(dnl --enable-debug-print[=yes]:
+		     [test "x$enableval" = "xyes"],
+		     [debug_print_info="$enableval (EM_DEBUG_PRINT=1)"
+		      EM_DEBUG_PRINT="-DEM_DEBUG_PRINT=1"],
+		     dnl --disable-debug OR --enable-debug-print=no:
+		     [test "x$enableval" = "xno"],
+		     [debug_print_info="$enableval (EM_DEBUG_PRINT=0)"
+		      EM_DEBUG_PRINT="-DEM_DEBUG_PRINT=0"],
+		     dnl unsupported value given:
+		     [AC_MSG_ERROR([bad value --enable-debug-print=${enableval}, use yes/no])]
+		)
+		EM_CPPFLAGS="$EM_CPPFLAGS $EM_DEBUG_PRINT"
+	      ],[])
+# Substitute @EM_DEBUG_PRINT@ into the pkgconfig file libemodp.pc.in
+AC_SUBST([EM_DEBUG_PRINT])
 
 ##########################################################################
 # Default include setup
@@ -500,4 +530,5 @@ AC_MSG_RESULT([
 	=======================
 	EM check level:		${check_level_info}
 	EM ESV:			${esv_info}
+	EM debug print:		${debug_print_info}
 	])

--- a/include/event_machine.h
+++ b/include/event_machine.h
@@ -36,7 +36,7 @@
 
 /**
  * @file
- * Event Machine API v2.5
+ * Event Machine API v2.6
  *
  * This file includes all other needed EM headers
  */
@@ -54,7 +54,7 @@ extern "C" {
  * Minor API version number.
  * Updates and additions
  */
-#define EM_API_VERSION_MINOR 5
+#define EM_API_VERSION_MINOR 6
 
 /** @mainpage
  *

--- a/include/event_machine/README_API
+++ b/include/event_machine/README_API
@@ -6,12 +6,133 @@ OpenEM API Release Notes
 - See em-odp/CHANGE_NOTES for changed and added features.
 
 -------------------------------------------------------------------------------
+API 2.6 (EM_API_VERSION_MAJOR=2, EM_API_VERSION_MINOR=6)
+-------------------------------------------------------------------------------
+Backwards compatible with EM 2.5 API
+
+1. Timer:
+   (see em-odp/include/event_machine/add-ons/event_machine_timer.h for details)
+  - Add new timer clock source choices (em_timer_clksrc_t) to select the
+    timer clock source in case multiple are supported:
+    EM_TIMER_CLKSRC_0, EM_TIMER_CLKSRC_1, ...(up to)..., EM_TIMER_CLKSRC_5.
+    Backwards compatible macros (EM_TIMER_CLKSRC_CPU, EM_TIMER_CLKSRC_EXT) are
+    provided for full compatibility with older code.
+    EM_TIMER_CLKSRC_DEFAULT is always available and is a fully portable
+    definition.
+
+2. Event:
+   (see em-odp/include/event_machine/api/event_machine_event.h for details)
+  - Event cloning:
+    - em_event_t em_event_clone(em_event_t event, em_pool_t pool);
+      Allocate a new event with identical payload to the given event.
+      The event metadata and internal headers will _not_ be cloned.
+      The optional 'pool' argument is used to specify the event pool to allocate
+      the cloned event from. Use 'EM_POOL_UNDEF' to clone from the same pool as
+      'event' was allocated from.
+      The event-type of 'event' must be suitable for allocation from 'pool'
+      (e.g. EM_EVENT_TYPE_PACKET can not be allocated from a pool supporting
+      only EM_EVENT_TYPE_SW)
+      The function returns the cloned event or EM_EVENT_UNDEF on error.
+
+  - Event/Pool: Get the handle of the pool the event was allocated from.
+    - em_pool_t em_event_get_pool(em_event_t event);
+      Returns the EM event-pool the event was allocated from or EM_POOL_UNDEF if
+      no EM pool is found. EM_POOL_UNDEF is returned also for a valid event that
+      has been allocated from a pool external to EM (no error is reported).
+      The EM event-pool for the given event can only be obtained if the event
+      has been allocated from a pool created with em_pool_create(). For other
+      pools, e.g. external (to EM) pktio pools, EM_POOL_UNDEF is returned.
+
+  - Marking event(s) as "free"
+    - void em_event_mark_free(em_event_t event);
+    - void em_event_mark_free_multi(const em_event_t events[], int num);
+    Mark the event state as "free" and then rely on HW / mechanisms external
+    to EM to actually free the event(s) back into the event pool.
+    - em_event_mark_free(): Indicates a user-given promise to EM that the event
+      will be freed back into the pool it was allocated from e.g. by HW or
+      device drivers (external to EM). Calling em_event_mark_free() transfers
+      event ownership away from the user, and thus the event must not be used or
+      touched by the user anymore.
+      EM will, after this API-call, treat the event as "freed" and any further
+      API operations or usage might lead to EM errors (depending on the
+      error-check level), e.g. em_send/free/tmo_set/ack(event) etc. is forbidden
+      after em_event_mark_free(event).
+    - em_event_mark_free_multi(): Similar to em_event_mark_free(), but allows
+      the marking of multiple events as "free" with one function call.
+    Note: Registered API-callback hooks for em_free/_multi()
+          (em_api_hook_free_t) will NOT be called.
+
+ - Unmarking event(s) previously marked "free"
+    - void em_event_unmark_free(em_event_t event);
+    - void em_event_unmark_free_multi(const em_event_t events[], int num);
+    Unmark event(s) previously marked as "free" (i.e mark as "allocated" again).
+    Note: This is for recovery situations only and can potenially crash the
+          application if used incorrectly! Unmarking the free-state of an event
+          that has already been freed will lead to fatal error.
+    - em_event_unmark_free(): Revert an event's "free" state, as set by
+      em_event_mark_free() back to the state before the mark-free function call.
+      Any further usage of the event after em_event_mark_free(), by EM or the
+      user, will result in error when calling em_event_unmark_free() since the
+      state has become unrecoverable.
+      => the only allowed EM API call after em_event_mark_free() (for a certain
+         event) is em_event_unmark_free() when it is certain that the event, due
+         to some external error, will not be freed otherwise and must be
+         recovered back into the EM-domain so that calling em_free() by the user
+         is possible.
+      Calling em_event_unmark_free() transfers event ownership back to the user
+      again.
+      Note: Unmark-send and unmark-free are the only valid cases of using an
+            event that the user no longer owns, all other such uses leads to
+	    fatal error.
+    - em_event_unmark_free_multi(): Unmark multiple events previously marked as
+      "free". Similar to em_event_unmark_free(), but allows to do the
+      "free"-unmarking of multiple events with one function call.
+
+3. Queue:
+  (see em-odp/include/event_machine/api/event_machine_queue.h)
+  - Number of queue priorities:
+    - int em_queue_get_num_prio(int *num_runtime);
+      The function returns the number of queue priorities available.
+      Optionally, the amount of actual runtime priorities can be inquired.
+      The valid queue priority range is from 0 (lowest priority) to
+      em_queue_get_num_prio() - 1.
+      The runtime environment may provide a different amount of priority levels.
+      EM priorities are in that case mapped to the runtime values depending on
+      "priority map-mode" selected in the runtime configuration file
+      (config/em-odp.conf).
+
+4. Extension APIs for EM<->ODP conversions:
+   (see include/event_machine/platform/event_machine_odp_ext.h)
+  - Convert between EM and ODP pools:
+    - int em_odp_pool2odp(em_pool_t pool, odp_pool_t odp_pools[/out/], int num);
+    - em_pool_t em_odp_pool2em(odp_pool_t odp_pool);
+
+    - em_odp_pool2odp(): Get the ODP pools used as subpools in a given EM event
+      pool. An EM event pool consists of 1 to 'EM_MAX_SUBPOOLS' subpools. Each
+      subpool is an ODP pool. This function outputs the ODP pool handles of
+      these subpools into a user-provided array and returns the number of
+      handles written. The obtained ODP pools must not be deleted or altered
+      outside of EM, e.g. these ODP pools must only be deleted as part of an
+      EM event pool using em_pool_delete().
+      ODP pool handles obtained through this function can be used to
+        - configure ODP pktio to use an ODP pool created via EM (allows for
+          better ESV tracking)
+        - print ODP-level pool statistics with ODP APIs etc.
+      The function returns the number of ODP pools filled into 'odp_pools[]'.
+
+    - em_odp_pool2em(): Get the EM event pool that a given ODP pool belongs to.
+      An EM event pool consists of 1 to 'EM_MAX_SUBPOOLS' subpools. Each subpool
+      is an ODP pool. This function returns the EM event pool that contains the
+      given ODP pool as a subpool or EM_POOL_UNDEF if the ODP pool is not part
+      of any EM event pool.
+
+-------------------------------------------------------------------------------
 API 2.5 (EM_API_VERSION_MAJOR=2, EM_API_VERSION_MINOR=5)
 -------------------------------------------------------------------------------
 Not backwards compatible with previous API version, API 2.5 contains modified
 types and functions requiring small changes to older code.
 
-1. EM Timer: timer version updated from v2.0 to v2.1,
+1. Timer: timer version updated from v2.0 to v2.1,
    see em-odp/include/event_machine/add-ons/event_machine_timer.h for details.
    - New Timer APIs for tick<->ns conversions:
      - em_timer_tick_to_ns()
@@ -79,7 +200,7 @@ API 2.4 (EM_API_VERSION_MAJOR=2, EM_API_VERSION_MINOR=4)
 Not backwards compatible with previous API version, API 2.4 contains modified
 types requiring small changes to older code.
 
-1. EM Timer: timer version updated from v1.1 to v2.0,
+1. Timer: timer version updated from v1.1 to v2.0,
    see em-odp/include/event_machine/add-ons/event_machine_timer.h for details.
    New or updated timer types and APIs:
    - em_timer_attr_t: *updated* type that MUST be initialized with

--- a/include/event_machine/add-ons/templates/event_machine_timer_hw_specific.h.template
+++ b/include/event_machine/add-ons/templates/event_machine_timer_hw_specific.h.template
@@ -83,21 +83,26 @@ typedef enum em_tmo_flag_t {
 } em_tmo_flag_t;
 
 /*
- * em_timer_clksrc_t is used to select the timer clock source.
+ * em_timer_clksrc_t is used to select the timer clock source in case multiple
+ * are supported.
  *
- * EM_TIMER_CLKSRC_DEFAULT is a standard definition, but more can be declared.
+ * EM_TIMER_CLKSRC_DEFAULT is a portable definition, but more can be defined.
  * The default clock source could e.g. use the CPU internal timer and another
  * value for a separate timer running out of an external clock/trigger with
  * different resolution.
  */
 typedef enum em_timer_clksrc_t {
-	/** Portable default clock source */
-	EM_TIMER_CLKSRC_DEFAULT = 0,
-	/** CPU clock as clock source */
-	EM_TIMER_CLKSRC_CPU  = 1,
-	/** External clock source */
-	EM_TIMER_CLKSRC_EXT = 2
+	EM_TIMER_CLKSRC_0,
+	EM_TIMER_CLKSRC_1,
+	EM_TIMER_CLKSRC_2,
+	EM_TIMER_CLKSRC_3,
+	EM_TIMER_CLKSRC_4,
+	EM_TIMER_CLKSRC_5,
+	EM_TIMER_NUM_CLKSRC
 } em_timer_clksrc_t;
+
+/** portable default clock */
+#define EM_TIMER_CLKSRC_DEFAULT EM_TIMER_CLKSRC_0
 
 /**
  * EM_TIMER_UNDEF value must be defined here and should normally be 0

--- a/include/event_machine/api/event_machine_queue.h
+++ b/include/event_machine/api/event_machine_queue.h
@@ -472,6 +472,27 @@ em_queue_get_next(void);
 int em_queue_get_index(em_queue_t queue);
 
 /**
+ * Returns the number of queue priorities available.
+ *
+ * Optionally the amount of actual runtime priorities can be inquired.
+ * Valid queue priority range is from 0 (lowest priority) to
+ * em_queue_get_num_prio() - 1.
+ *
+ * Runtime environment may provide different amount of levels. In that case EM
+ * priorities are mapped to the runtime values depending on mapping mode
+ * selected in the runtime configuration file.
+ *
+ * @param[out] num_runtime	Pointer to an int to receive the number of
+ *				actual runtime priorities. Set to NULL if
+ *				not needed.
+ *
+ * @return	number of queue priorities
+ *
+ * @see em-odp.conf
+ */
+int em_queue_get_num_prio(int *num_runtime);
+
+/**
  * @}
  */
 #ifdef __cplusplus

--- a/include/event_machine/api/event_machine_types.h
+++ b/include/event_machine/api/event_machine_types.h
@@ -169,17 +169,18 @@ typedef uint32_t em_queue_type_t;
 
 /**
  * @typedef em_queue_prio_t
- * Queue priority class
+ * Queue priority
  *
- * Queue priority defines a system dependent QoS class, not just an absolute
- * priority. EM gives freedom to implement the actual scheduling disciplines
- * and the corresponding numeric values as needed, i.e. the actual values are
- * system dependent and thus not portable, but the 5 predefined enums
- * (em_queue_prio_e) are always valid.
- * Application platform or middleware needs to define and distribute the
- * other available values.
+ * Queue priority defines implementation specific QoS class for event
+ * scheduling. Priority is an integer in range 0 (lowest) to num priorities - 1.
+ * Note, that the exact scheduling rules are not defined by EM and all available
+ * priorities may not be relative to the adjacent one (e.g. using dynamic
+ * priority, rate limiting or other more complex scheduling discipline).
+ * There are 5 generic predefined values (em_queue_prio_e) mapped to available
+ * runtime priorities for portability.
  *
- * @see em_queue_create(), event_machine_hw_config.h
+ * @see em_queue_create(), em_queue_get_num_prio(), event_machine_hw_config.h,
+ *      em_queue_prio_e
  */
 typedef uint32_t em_queue_prio_t;
 #define PRI_QPRIO  PRIu32
@@ -471,12 +472,18 @@ typedef uint32_t em_escope_t;
 #define EM_ESCOPE_SEND_MULTI                      (EM_ESCOPE_API_MASK | 0x0606)
 #define EM_ESCOPE_EVENT_POINTER                   (EM_ESCOPE_API_MASK | 0x0607)
 #define EM_ESCOPE_EVENT_GET_SIZE                  (EM_ESCOPE_API_MASK | 0x0608)
-#define EM_ESCOPE_EVENT_SET_TYPE                  (EM_ESCOPE_API_MASK | 0x0609)
-#define EM_ESCOPE_EVENT_GET_TYPE                  (EM_ESCOPE_API_MASK | 0x060A)
-#define EM_ESCOPE_EVENT_GET_TYPE_MULTI            (EM_ESCOPE_API_MASK | 0x060B)
-#define EM_ESCOPE_EVENT_SAME_TYPE_MULTI           (EM_ESCOPE_API_MASK | 0x060C)
-#define EM_ESCOPE_EVENT_MARK_SEND                 (EM_ESCOPE_API_MASK | 0x060D)
-#define EM_ESCOPE_EVENT_UNMARK_SEND               (EM_ESCOPE_API_MASK | 0x060E)
+#define EM_ESCOPE_EVENT_GET_POOL                  (EM_ESCOPE_API_MASK | 0x0609)
+#define EM_ESCOPE_EVENT_SET_TYPE                  (EM_ESCOPE_API_MASK | 0x060A)
+#define EM_ESCOPE_EVENT_GET_TYPE                  (EM_ESCOPE_API_MASK | 0x060B)
+#define EM_ESCOPE_EVENT_GET_TYPE_MULTI            (EM_ESCOPE_API_MASK | 0x060C)
+#define EM_ESCOPE_EVENT_SAME_TYPE_MULTI           (EM_ESCOPE_API_MASK | 0x060D)
+#define EM_ESCOPE_EVENT_MARK_SEND                 (EM_ESCOPE_API_MASK | 0x060E)
+#define EM_ESCOPE_EVENT_UNMARK_SEND               (EM_ESCOPE_API_MASK | 0x060F)
+#define EM_ESCOPE_EVENT_MARK_FREE                 (EM_ESCOPE_API_MASK | 0x0610)
+#define EM_ESCOPE_EVENT_UNMARK_FREE               (EM_ESCOPE_API_MASK | 0x0611)
+#define EM_ESCOPE_EVENT_MARK_FREE_MULTI           (EM_ESCOPE_API_MASK | 0x0612)
+#define EM_ESCOPE_EVENT_UNMARK_FREE_MULTI         (EM_ESCOPE_API_MASK | 0x0613)
+#define EM_ESCOPE_EVENT_CLONE                     (EM_ESCOPE_API_MASK | 0x0614)
 
 /* EM API escopes: Queue Group */
 #define EM_ESCOPE_QUEUE_GROUP_CREATE              (EM_ESCOPE_API_MASK | 0x0701)
@@ -510,6 +517,7 @@ typedef uint32_t em_escope_t;
 #define EM_ESCOPE_QUEUE_GET_FIRST                 (EM_ESCOPE_API_MASK | 0x080E)
 #define EM_ESCOPE_QUEUE_GET_NEXT                  (EM_ESCOPE_API_MASK | 0x080F)
 #define EM_ESCOPE_QUEUE_GET_INDEX                 (EM_ESCOPE_API_MASK | 0x0810)
+#define EM_ESCOPE_QUEUE_GET_NUM_PRIO		  (EM_ESCOPE_API_MASK | 0x0811)
 
 /* EM API escopes: Scheduler */
 #define EM_ESCOPE_ATOMIC_PROCESSING_END           (EM_ESCOPE_API_MASK | 0x0901)

--- a/include/event_machine/platform/add-ons/event_machine_timer_hw_specific.h
+++ b/include/event_machine/platform/add-ons/event_machine_timer_hw_specific.h
@@ -82,21 +82,33 @@ typedef enum em_tmo_flag_t {
 } em_tmo_flag_t;
 
 /*
- * em_timer_clksrc_t is used to select the timer clock source.
+ * em_timer_clksrc_t is used to select the timer clock source in case multiple
+ * are supported.
  *
- * EM_TIMER_CLKSRC_DEFAULT is a standard definition, but more can be declared.
- * The default clock source could e.g. use the CPU internal timer and another
- * value for a separate timer running out of an external clock/trigger with
- * different resolution.
+ * EM_TIMER_CLKSRC_DEFAULT is always available portable definition. More
+ * can be defined (implementation specific).
  */
 typedef enum em_timer_clksrc_t {
-	/** Portable default clock source */
-	EM_TIMER_CLKSRC_DEFAULT = 0,
-	/** CPU clock as clock source */
-	EM_TIMER_CLKSRC_CPU  = 1,
-	/** External clock source */
-	EM_TIMER_CLKSRC_EXT = 2
+	EM_TIMER_CLKSRC_0,
+	EM_TIMER_CLKSRC_1,
+	EM_TIMER_CLKSRC_2,
+	EM_TIMER_CLKSRC_3,
+	EM_TIMER_CLKSRC_4,
+	EM_TIMER_CLKSRC_5,
+	EM_TIMER_NUM_CLKSRC
 } em_timer_clksrc_t;
+
+/** portable default clock */
+#define EM_TIMER_CLKSRC_DEFAULT EM_TIMER_CLKSRC_0
+
+/** Backwards compatible macro.
+ * @deprecated Temporary backwards compatibility, will be removed later
+ */
+#define EM_TIMER_CLKSRC_CPU	EM_TIMER_CLKSRC_0
+/** Backwards compatible macro.
+ * @deprecated Temporary backwards compatibility, will be removed later
+ */
+#define EM_TIMER_CLKSRC_EXT	EM_TIMER_CLKSRC_2
 
 /**
  * EM_TIMER_UNDEF value must be defined here and should normally be 0

--- a/include/event_machine/platform/event_machine_config.h
+++ b/include/event_machine/platform/event_machine_config.h
@@ -235,6 +235,23 @@ extern "C" {
 #endif
 
 /**
+ * @def EM_DEBUG_PRINT
+ * Event Machine Debug Printouts
+ *
+ * '0': disabled
+ * '1': enabled
+ *
+ * @note em-odp: the 'EM_DEBUG_PRINT' value can be overridden by a command-line
+ *               option to the 'configure' script, e.g.:
+ *               $build> ../configure ... --enable-debug-print
+ *               The overridden value will be made available to the application
+ *               via a pkgconfig set define.
+ */
+#ifndef EM_DEBUG_PRINT
+#define EM_DEBUG_PRINT  0
+#endif
+
+/**
  * @def EM_EVENT_GROUP_SAFE_MODE
  * Guards event groups in undefined and error situations
  *

--- a/include/event_machine/platform/event_machine_hooks.h
+++ b/include/event_machine/platform/event_machine_hooks.h
@@ -59,10 +59,10 @@ extern "C" {
 #endif
 
 /**
- * API-callback hook for em_alloc() and em_alloc_multi().
+ * API-callback hook for em_alloc(), em_alloc_multi() and em_event_clone()
  *
- * The hook will only be called for successful allocs, passing also the newly
- * allocated 'events' to the hook.
+ * The hook will only be called for successful event allocations, passing also
+ * the newly allocated 'events' to the hook.
  * The state and ownership of the events must not be changed by the hook, e.g.
  * the events must not be freed or sent etc. Calling em_alloc/_multi() within
  * the alloc hook leads to hook recursion and must be avoided.

--- a/include/event_machine/platform/event_machine_hw_config.h
+++ b/include/event_machine/platform/event_machine_hw_config.h
@@ -100,7 +100,8 @@ extern "C" {
 
 /**
  * @def EM_QUEUE_PRIO_NUM
- * Number of queue scheduling priorities
+ * Number of queue scheduling priorities, normal default is 8.
+ * @see em_queue_prio_e
  */
 #define EM_QUEUE_PRIO_NUM  8
 

--- a/include/event_machine/platform/event_machine_hw_types.h
+++ b/include/event_machine/platform/event_machine_hw_types.h
@@ -121,18 +121,21 @@ typedef enum em_queue_type_e {
 /**
  * Portable queue priorities.
  *
- * Never directly use the numerical values as they may change from
- * one platform to the next; always use the enum names instead.
- * @see EM_QUEUE_PRIO_NUM
+ * These are generic portable values to use for priority.
+ *
+ * Alternatively application may choose to use numeric values in the valid
+ * range (from 0 to em_queue_get_num_prio() - 1).
+ *
+ * @see em_queue_prio_t, em_queue_get_num_prio()
  */
 typedef enum em_queue_prio_e {
-	EM_QUEUE_PRIO_UNDEF   = 0xFF, /**< Undefined */
 	EM_QUEUE_PRIO_LOWEST  = 0,    /**< Lowest */
 	EM_QUEUE_PRIO_LOW     = 2,    /**< Low */
 	EM_QUEUE_PRIO_NORMAL  = 4,    /**< Normal */
 	EM_QUEUE_PRIO_HIGH    = 6,    /**< High */
 	EM_QUEUE_PRIO_HIGHEST = 7     /**< Highest */
 } em_queue_prio_e;
+#define EM_QUEUE_PRIO_UNDEF 0xFF      /**< Undefined */
 
 /**
  * em_queue_flag_t values (system specific):

--- a/include/event_machine/platform/event_machine_odp_ext.h
+++ b/include/event_machine/platform/event_machine_odp_ext.h
@@ -32,7 +32,6 @@
  * @file
  *
  * Event Machine ODP API extensions
- *
  */
 
 #ifndef EVENT_MACHINE_ODP_EXT_H
@@ -128,6 +127,53 @@ em_odp_event2em(odp_event_t odp_event);
 void
 em_odp_events2em(const odp_event_t odp_events[], em_event_t events[/*out*/],
 		 const int num);
+
+/**
+ * @brief Get the ODP pools used as subpools in a given EM event pool.
+ *
+ * An EM event pool consists of 1 to 'EM_MAX_SUBPOOLS' subpools. Each subpool
+ * is an ODP pool. This function outputs the ODP pool handles of these subpools
+ * into a user-provided array and returns the number of handles written.
+ *
+ * The obtained ODP pools must not be deleted or alterede outside of EM,
+ * e.g. these ODP pools must only be deleted as part of an EM event pool
+ * using em_pool_delete().
+ *
+ * ODP pool handles obtained through this function can be used to
+ *  - configure ODP pktio to use an ODP pool created via EM (allows for
+ *    better ESV tracking)
+ *  - print ODP-level pool statistics with ODP APIs etc.
+ *
+ * Note that direct allocations and free:s via ODP APIs will bypass
+ * EM checks (e.g. ESV) and might cause errors unless properely handled:
+ *  - use em_odp_event2em() to initialize as an EM event
+ *  - use em_event_mark_free() before ODP-free operations (SW- or HW-free)
+ *
+ * @param      pool       EM event pool handle.
+ * @param[out] odp_pools  Output array to be filled with the ODP pools used as
+ *                        subpools in the given EM event pool. The array must
+ *                        fit 'num' entries.
+ * @param      num        Number of entries in the 'odp_pools[]' array.
+ *                        Using 'num=EM_MAX_SUBPOOLS' will always be large
+ *                        enough to fit all subpools in the EM event pool.
+ *
+ * @return The number of ODP pools filled into 'odp_pools[]'
+ */
+int em_odp_pool2odp(em_pool_t pool, odp_pool_t odp_pools[/*out*/], int num);
+
+/**
+ * @brief Get the EM event pool that the given ODP pool belongs to
+ *
+ * An EM event pool consists of 1 to 'EM_MAX_SUBPOOLS' subpools. Each subpool
+ * is an ODP pool. This function returns the EM event pool that contains the
+ * given ODP pool as a subpool.
+ *
+ * @param odp_pool
+ *
+ * @return The EM event pool that contains the subpool 'odp_pool' or
+ *         EM_POOL_UNDEF if 'odp_pool' is not part of any EM event pool.
+ */
+em_pool_t em_odp_pool2em(odp_pool_t odp_pool);
 
 /**
  * Enqueue packets into EM (from outside of EM, not allocated by em_alloc())

--- a/m4/em_libconfig.m4
+++ b/m4/em_libconfig.m4
@@ -3,7 +3,7 @@
 ##########################################################################
 m4_define([_em_config_version_generation], [0])
 m4_define([_em_config_version_major], [0])
-m4_define([_em_config_version_minor], [8])
+m4_define([_em_config_version_minor], [9])
 
 m4_define([_em_config_version],
 	  [_em_config_version_generation._em_config_version_major._em_config_version_minor])

--- a/pkgconfig/libemodp.pc.in
+++ b/pkgconfig/libemodp.pc.in
@@ -9,4 +9,4 @@ Version: @EMODP_PKGCONFIG_VERSION@
 Requires: @libodp_name@
 Requires.private: libconfig
 Libs: -L${libdir} -lemodp
-Cflags: -I${includedir} @EM_CHECK_LEVEL@ @EM_ESV_ENABLE@
+Cflags: -I${includedir} @EM_CHECK_LEVEL@ @EM_ESV_ENABLE@ @EM_DEBUG_PRINT@

--- a/programs/common/cm_setup.h
+++ b/programs/common/cm_setup.h
@@ -121,6 +121,11 @@ typedef struct {
 		char if_name[IF_MAX_NUM][IF_NAME_LEN + 1];
 		/** Interface identifiers corresponding to 'if_name[]' */
 		int if_ids[IF_MAX_NUM];
+		/**
+		 * Pktio is setup with an EM event-pool: 'true'
+		 * Pktio is setup with an ODP pkt-pool:  'false'
+		 */
+		bool pktpool_em;
 	} pktio;
 } appl_conf_t;
 

--- a/programs/packet_io/.gitignore
+++ b/programs/packet_io/.gitignore
@@ -3,3 +3,5 @@ loopback_ag
 loopback_local
 multi_stage
 multi_stage_local
+loopback_local_multircv
+loopback_multircv

--- a/programs/performance/.gitignore
+++ b/programs/performance/.gitignore
@@ -7,3 +7,4 @@ queues_local
 queues_unscheduled
 send_multi
 timer_test_periodic
+loop_multircv

--- a/programs/performance/queues_unscheduled.c
+++ b/programs/performance/queues_unscheduled.c
@@ -468,6 +468,9 @@ test_start(appl_conf_t *const appl_conf)
 	queue_step();
 }
 
+/**
+ * Stop the test, only run on one core
+ */
 void
 test_stop(appl_conf_t *const appl_conf)
 {
@@ -480,15 +483,22 @@ test_stop(appl_conf_t *const appl_conf)
 
 	APPL_PRINT("%s() on EM-core %d\n", __func__, core);
 
-	/* Stop & delete EOs */
+	/* Stop EOs */
 	for (i = 0; i < NUM_EOS; i++) {
 		eo = perf_shm->eo[i];
-
 		ret = em_eo_stop_sync(eo);
 		test_fatal_if(ret != EM_OK,
 			      "EO:%" PRI_EO " stop:%" PRI_STAT "",
 			      eo, ret);
+	}
 
+	/* Remove and delete all of the EO's queues, then delete the EO */
+	for (i = 0; i < NUM_EOS; i++) {
+		eo = perf_shm->eo[i];
+		ret = em_eo_remove_queue_all_sync(eo, EM_TRUE/*delete Qs*/);
+		test_fatal_if(ret != EM_OK,
+			      "EO remove queue all:%" PRI_STAT " EO:%" PRI_EO "",
+			      ret, eo);
 		ret = em_eo_delete(eo);
 		test_fatal_if(ret != EM_OK,
 			      "EO:%" PRI_EO " delete:%" PRI_STAT "",
@@ -516,6 +526,9 @@ test_stop(appl_conf_t *const appl_conf)
 	}
 }
 
+/**
+ * Terminate the test, only run on one core
+ */
 void
 test_term(void)
 {
@@ -523,10 +536,8 @@ test_term(void)
 
 	APPL_PRINT("%s() on EM-core %d\n", __func__, core);
 
-	if (core == 0) {
-		env_shared_free(perf_shm);
-		em_unregister_error_handler();
-	}
+	env_shared_free(perf_shm);
+	em_unregister_error_handler();
 }
 
 /**
@@ -692,17 +703,9 @@ start(void *eo_context, em_eo_t eo, const em_eo_conf_t *conf)
 static em_status_t
 stop(void *eo_context, em_eo_t eo)
 {
-	em_status_t ret;
-
 	(void)eo_context;
 
 	APPL_PRINT("EO %" PRI_EO " stopping.\n", eo);
-
-	/* remove and delete all of the EO's queues */
-	ret = em_eo_remove_queue_all_sync(eo, EM_TRUE);
-	test_fatal_if(ret != EM_OK,
-		      "EO remove queue all:%" PRI_STAT " EO:%" PRI_EO "",
-		      ret, eo);
 
 	return EM_OK;
 }

--- a/scripts/style_check.py
+++ b/scripts/style_check.py
@@ -33,7 +33,7 @@ def run_checks():
         # if file.endswith(('.c', '.h')):
         cmd = C_CHECK + file
 
-        if os.system(cmd) is not 0:
+        if os.system(cmd) != 0:
             rc = 1
 
 rc = 0

--- a/src/add-ons/event_timer/em_timer.h
+++ b/src/add-ons/event_timer/em_timer.h
@@ -32,15 +32,8 @@
 
 #include "em_timer_types.h"
 
-/*#define TIMER_DEBUG*/
-
-#ifdef TIMER_DEBUG
-#include <stdio.h>
-#define TMR_DBG_PRINT(format, ...) \
-	EM_LOG(EM_LOG_DBG, "TMRDBG: " format, __VA_ARGS__)
-#else
-#define TMR_DBG_PRINT(format, ...) do {} while (0)
-#endif
+#define TMR_DBG_PRINT(fmt, ...) \
+	EM_DBG("TMRDBG: %s(): " fmt, __func__, ## __VA_ARGS__)
 
 em_status_t timer_init(timer_storage_t *const tmrs);
 em_status_t timer_init_local(void);
@@ -52,16 +45,28 @@ timer_clksrc_em2odp(em_timer_clksrc_t clksrc_em,
 		    odp_timer_clk_src_t *clksrc_odp /* out */)
 {
 	switch (clksrc_em) {
-	case EM_TIMER_CLKSRC_DEFAULT: /* fallthrough */
-	case EM_TIMER_CLKSRC_CPU:
-		*clksrc_odp = ODP_CLOCK_CPU;
-		return 0;
-	case EM_TIMER_CLKSRC_EXT:
-		*clksrc_odp = ODP_CLOCK_EXT;
-		return 0;
+	case EM_TIMER_CLKSRC_0:
+		*clksrc_odp = ODP_CLOCK_SRC_0;
+		break;
+	case EM_TIMER_CLKSRC_1:
+		*clksrc_odp = ODP_CLOCK_SRC_1;
+		break;
+	case EM_TIMER_CLKSRC_2:
+		*clksrc_odp = ODP_CLOCK_SRC_2;
+		break;
+	case EM_TIMER_CLKSRC_3:
+		*clksrc_odp = ODP_CLOCK_SRC_3;
+		break;
+	case EM_TIMER_CLKSRC_4:
+		*clksrc_odp = ODP_CLOCK_SRC_4;
+		break;
+	case EM_TIMER_CLKSRC_5:
+		*clksrc_odp = ODP_CLOCK_SRC_5;
+		break;
 	default:
 		return -1;
 	}
+	return 0;
 }
 
 static inline int
@@ -69,15 +74,28 @@ timer_clksrc_odp2em(odp_timer_clk_src_t clksrc_odp,
 		    em_timer_clksrc_t *clksrc_em /* out */)
 {
 	switch (clksrc_odp) {
-	case ODP_CLOCK_CPU:
-		*clksrc_em = EM_TIMER_CLKSRC_CPU;
-		return 0;
-	case ODP_CLOCK_EXT:
-		*clksrc_em = EM_TIMER_CLKSRC_EXT;
-		return 0;
+	case ODP_CLOCK_SRC_0:
+		*clksrc_em = EM_TIMER_CLKSRC_0;
+		break;
+	case ODP_CLOCK_SRC_1:
+		*clksrc_em = EM_TIMER_CLKSRC_1;
+		break;
+	case ODP_CLOCK_SRC_2:
+		*clksrc_em = EM_TIMER_CLKSRC_2;
+		break;
+	case ODP_CLOCK_SRC_3:
+		*clksrc_em = EM_TIMER_CLKSRC_3;
+		break;
+	case ODP_CLOCK_SRC_4:
+		*clksrc_em = EM_TIMER_CLKSRC_4;
+		break;
+	case ODP_CLOCK_SRC_5:
+		*clksrc_em = EM_TIMER_CLKSRC_5;
+		break;
 	default:
 		return -1;
 	}
+	return 0;
 }
 
 #endif /* EM_TIMER_H_ */

--- a/src/em_error.h
+++ b/src/em_error.h
@@ -40,25 +40,33 @@
 /**
  * Internal error reporting macro
  */
-#define INTERNAL_ERROR(error, escope, format, ...)		\
+#define INTERNAL_ERROR(error, escope, fmt, ...)		\
 	internal_error((error), (escope), __FILE__, __func__,	\
-			__LINE__, (format), ## __VA_ARGS__)
+			__LINE__, fmt, ## __VA_ARGS__)
 
 /**
  * Internal macro for return on error
  */
-#define RETURN_ERROR_IF(cond, error, escope, format, ...) {	  \
+#define RETURN_ERROR_IF(cond, error, escope, fmt, ...) {	  \
 	if (unlikely((cond))) {					  \
 		return INTERNAL_ERROR((error), (escope),	  \
-				      (format), ## __VA_ARGS__);  \
+				      fmt, ## __VA_ARGS__);  \
 	}							  \
 }
 
-#define EM_LOG(level, ...) (em_shm->log_fn((level), ## __VA_ARGS__))
+#define EM_LOG(level, fmt, ...) (em_shm->log_fn((level), fmt, ## __VA_ARGS__))
 
-#define EM_VLOG(level, fmt, args) (em_shm->vlog_fn((level), (fmt), (args)))
+#define EM_VLOG(level, fmt, args) (em_shm->vlog_fn((level), fmt, (args)))
 
-#define EM_PRINT(...) EM_LOG(EM_LOG_PRINT, ## __VA_ARGS__)
+#define EM_PRINT(fmt, ...) EM_LOG(EM_LOG_PRINT, fmt, ## __VA_ARGS__)
+
+/*
+ * Print debug message to log (only if EM_DEBUG_PRINT is set)
+ */
+#define EM_DBG(fmt, ...) {				\
+	if (EM_DEBUG_PRINT == 1)			\
+		EM_LOG(EM_LOG_DBG, fmt, ##__VA_ARGS__); \
+}
 
 /**
  * EM internal error

--- a/src/em_event_state.h
+++ b/src/em_event_state.h
@@ -46,51 +46,57 @@ extern "C" {
 #define EVSTATE__PREALLOC                      1
 #define EVSTATE__ALLOC                         2
 #define EVSTATE__ALLOC_MULTI                   3
-#define EVSTATE__FREE                          4
-#define EVSTATE__FREE_MULTI                    5
-#define EVSTATE__INIT                          6
-#define EVSTATE__INIT_MULTI                    7
-#define EVSTATE__INIT_EXTEV                    8
-#define EVSTATE__INIT_EXTEV_MULTI              9
-#define EVSTATE__SEND                         10
-#define EVSTATE__SEND__FAIL                   11
-#define EVSTATE__SEND_EGRP                    12
-#define EVSTATE__SEND_EGRP__FAIL              13
-#define EVSTATE__SEND_MULTI                   14
-#define EVSTATE__SEND_MULTI__FAIL             15
-#define EVSTATE__SEND_EGRP_MULTI              16
-#define EVSTATE__SEND_EGRP_MULTI__FAIL        17
-#define EVSTATE__MARK_SEND                    18
-#define EVSTATE__UNMARK_SEND                  19
-#define EVSTATE__DISPATCH                     20
-#define EVSTATE__DISPATCH_MULTI               21
-#define EVSTATE__DISPATCH_SCHED__FAIL         22
-#define EVSTATE__DISPATCH_LOCAL__FAIL         23
-#define EVSTATE__DEQUEUE                      24
-#define EVSTATE__DEQUEUE_MULTI                25
-#define EVSTATE__OUTPUT                       26 /* before output-queue callback-fn */
-#define EVSTATE__OUTPUT__FAIL                 27
-#define EVSTATE__OUTPUT_MULTI                 28 /* before output-queue callback-fn */
-#define EVSTATE__OUTPUT_MULTI__FAIL           29
-#define EVSTATE__OUTPUT_CHAINING              30 /* before event_send_device() */
-#define EVSTATE__OUTPUT_CHAINING__FAIL        31
-#define EVSTATE__OUTPUT_CHAINING_MULTI        32 /* before event_send_device_multi()*/
-#define EVSTATE__OUTPUT_CHAINING_MULTI__FAIL  33 /* before event_send_device_multi()*/
-#define EVSTATE__TMO_SET_ABS                  34
-#define EVSTATE__TMO_SET_ABS__FAIL            35
-#define EVSTATE__TMO_SET_REL                  36
-#define EVSTATE__TMO_SET_REL__FAIL            37
-#define EVSTATE__TMO_SET_PERIODIC             38
-#define EVSTATE__TMO_SET_PERIODIC__FAIL       39
-#define EVSTATE__TMO_CANCEL                   40
-#define EVSTATE__TMO_ACK                      41
-#define EVSTATE__TMO_ACK__NOSKIP              42
-#define EVSTATE__TMO_ACK__FAIL                43
-#define EVSTATE__TMO_DELETE                   44
-#define EVSTATE__AG_DELETE                    45
-#define EVSTATE__TERM_CORE__QUEUE_LOCAL       46
-#define EVSTATE__TERM                         47
-#define EVSTATE__LAST                         48 /* Must be largest number! */
+#define EVSTATE__EVENT_CLONE                   4
+#define EVSTATE__FREE                          5
+#define EVSTATE__FREE_MULTI                    6
+#define EVSTATE__INIT                          7
+#define EVSTATE__INIT_MULTI                    8
+#define EVSTATE__INIT_EXTEV                    9
+#define EVSTATE__INIT_EXTEV_MULTI             10
+#define EVSTATE__UPDATE_EXTEV                 11
+#define EVSTATE__SEND                         12
+#define EVSTATE__SEND__FAIL                   13
+#define EVSTATE__SEND_EGRP                    14
+#define EVSTATE__SEND_EGRP__FAIL              15
+#define EVSTATE__SEND_MULTI                   16
+#define EVSTATE__SEND_MULTI__FAIL             17
+#define EVSTATE__SEND_EGRP_MULTI              18
+#define EVSTATE__SEND_EGRP_MULTI__FAIL        19
+#define EVSTATE__MARK_SEND                    20
+#define EVSTATE__UNMARK_SEND                  21
+#define EVSTATE__MARK_FREE                    22
+#define EVSTATE__UNMARK_FREE                  23
+#define EVSTATE__MARK_FREE_MULTI              24
+#define EVSTATE__UNMARK_FREE_MULTI            25
+#define EVSTATE__DISPATCH                     26
+#define EVSTATE__DISPATCH_MULTI               27
+#define EVSTATE__DISPATCH_SCHED__FAIL         28
+#define EVSTATE__DISPATCH_LOCAL__FAIL         29
+#define EVSTATE__DEQUEUE                      30
+#define EVSTATE__DEQUEUE_MULTI                31
+#define EVSTATE__OUTPUT                       32 /* before output-queue callback-fn */
+#define EVSTATE__OUTPUT__FAIL                 33
+#define EVSTATE__OUTPUT_MULTI                 34 /* before output-queue callback-fn */
+#define EVSTATE__OUTPUT_MULTI__FAIL           35
+#define EVSTATE__OUTPUT_CHAINING              36 /* before event_send_device() */
+#define EVSTATE__OUTPUT_CHAINING__FAIL        37
+#define EVSTATE__OUTPUT_CHAINING_MULTI        38 /* before event_send_device_multi()*/
+#define EVSTATE__OUTPUT_CHAINING_MULTI__FAIL  39 /* before event_send_device_multi()*/
+#define EVSTATE__TMO_SET_ABS                  40
+#define EVSTATE__TMO_SET_ABS__FAIL            41
+#define EVSTATE__TMO_SET_REL                  42
+#define EVSTATE__TMO_SET_REL__FAIL            43
+#define EVSTATE__TMO_SET_PERIODIC             44
+#define EVSTATE__TMO_SET_PERIODIC__FAIL       45
+#define EVSTATE__TMO_CANCEL                   46
+#define EVSTATE__TMO_ACK                      47
+#define EVSTATE__TMO_ACK__NOSKIP              48
+#define EVSTATE__TMO_ACK__FAIL                49
+#define EVSTATE__TMO_DELETE                   50
+#define EVSTATE__AG_DELETE                    51
+#define EVSTATE__TERM_CORE__QUEUE_LOCAL       52
+#define EVSTATE__TERM                         53
+#define EVSTATE__LAST                         54 /* Must be largest number! */
 
 /**
  * Init values for the event-state counters 'free_cnt' and 'send_cnt'.
@@ -121,7 +127,6 @@ static inline bool esv_enabled(void)
  * Init ESV (if enabled at compile time), read config options
  */
 em_status_t esv_init(void);
-
 /**
  * Set the initial event state during em_pool_create() when preallocating events
  */
@@ -135,40 +140,57 @@ em_event_t evstate_alloc(const em_event_t event, event_hdr_t *const ev_hdr);
  */
 void evstate_alloc_multi(em_event_t ev_tbl[/*in/out*/],
 			 event_hdr_t *const ev_hdr_tbl[], const int num);
+/**
+ * Check & update event state during em_event_clone()
+ */
+em_event_t evstate_clone(const em_event_t event, event_hdr_t *const ev_hdr);
 
 /**
  * Set the initial state for an event
  * (e.g. an new odp-event converted into an EM-event)
  */
-em_event_t evstate_init(const em_event_t event, event_hdr_t *const ev_hdr);
+em_event_t evstate_init(const em_event_t event, event_hdr_t *const ev_hdr,
+			bool is_extev);
 /**
  * Set the initial state for events
  * (e.g. new odp-events converted into EM-events)
  */
 void evstate_init_multi(em_event_t ev_tbl[/*in/out*/],
-			event_hdr_t *const ev_hdr_tbl[], const int num);
-/**
- * Set the initial state for an external event input into EM
- * (e.g. an external odp pktio event input into EM and seen in the dispatcher)
- */
-em_event_t evstate_init_extev(em_event_t event, event_hdr_t *const ev_hdr);
-/**
- * Set the initial state for external events input into EM
- * (e.g. external odp pktio events input into EM and seen in the dispatcher)
- */
-void evstate_init_extev_multi(em_event_t ev_tbl[/*in/out*/],
-			      event_hdr_t *const ev_hdr_tbl[], const int num);
+			event_hdr_t *const ev_hdr_tbl[], const int num,
+			bool is_extev);
 
 /**
- * Check & update event state during em_free()
+ * Update the state for external events input into EM.
+ * Used when esv.prealloc_pools = true and the input event was allocated
+ * externally to EM (e.g. by ODP) but from an EM event-pool.
  */
-void evstate_free(em_event_t event, event_hdr_t *const ev_hdr);
+em_event_t evstate_update(const em_event_t event,
+			  event_hdr_t *const ev_hdr, bool is_extev);
+
 /**
- * Check & update the state of multiple events during em_free_multi()
+ * Check & update event state during em_free() or em_event_mark_free()
+ */
+void evstate_free(em_event_t event, event_hdr_t *const ev_hdr,
+		  const uint16_t api_op);
+/**
+ * Check & update event state during em_event_unmark_free()
+ */
+void evstate_free_revert(em_event_t event, event_hdr_t *const ev_hdr,
+			 const uint16_t api_op);
+
+/**
+ * Check & update the state of multiple events during em_free_multi() or
+ * em_event_mark_free_multi()
  */
 void evstate_free_multi(const em_event_t ev_tbl[],
-			event_hdr_t *const ev_hdr_tbl[], const int num);
-
+			event_hdr_t *const ev_hdr_tbl[], const int num,
+			const uint16_t api_op);
+/**
+ * Check & update event state during em_event_unmark_free_multi()
+ */
+void evstate_free_revert_multi(const em_event_t ev_tbl[],
+			       event_hdr_t *const ev_hdr_tbl[], const int num,
+			       const uint16_t api_op);
 /**
  * Check & update event state - event passed from EM to user.
  *
@@ -195,7 +217,6 @@ void evstate_em2usr_multi(em_event_t ev_tbl[/*in/out*/],
 void evstate_em2usr_revert_multi(em_event_t ev_tbl[/*in/out*/],
 				 event_hdr_t *const ev_hdr_tbl[], const int num,
 				 const uint16_t api_op);
-
 /**
  * Check & update event state - event passed from the user to EM.
  *
@@ -208,7 +229,6 @@ void evstate_usr2em(em_event_t event, event_hdr_t *const ev_hdr,
  */
 void evstate_usr2em_revert(em_event_t event, event_hdr_t *const ev_hdr,
 			   const uint16_t api_op);
-
 /**
  * Check & update the state of multiple events - events passed from user to EM
  *
@@ -223,6 +243,33 @@ void evstate_usr2em_multi(const em_event_t ev_tbl[],
 void evstate_usr2em_revert_multi(const em_event_t ev_tbl[],
 				 event_hdr_t *const ev_hdr_tbl[], const int num,
 				 const uint16_t api_op);
+/**
+ * Check & update event state during em_event_unmark_send()
+ *
+ * Wrapper function for evstate_usr2em_revert(..., EVSTATE__UNMARK_SEND) with
+ * extra error checks.
+ */
+void evstate_unmark_send(const em_event_t event, event_hdr_t *const ev_hdr);
+
+/**
+ * Check & update event state during em_event_unmark_free()
+ *
+ * Wrapper function for evstate_free_revert(..., EVSTATE__UNMARK_FREE) with
+ * extra error checks.
+ */
+void evstate_unmark_free(const em_event_t event, event_hdr_t *const ev_hdr);
+
+/**
+ * Check & update event state for multiple events during
+ * em_event_unmark_free_multi()
+ *
+ * Wrapper function for
+ * evstate_free_revert_multi(..., EVSTATE__UNMARK_FREE_MULTI)
+ * with extra error checks.
+ */
+void evstate_unmark_free_multi(const em_event_t ev_tbl[],
+			       event_hdr_t *const ev_hdr_tbl[], const int num);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/em_init.h
+++ b/src/em_init.h
@@ -67,6 +67,10 @@ typedef struct {
 
 	struct {
 		unsigned int min_events_default; /* default min nbr of events */
+		struct {
+		int map_mode;
+		int custom_map[EM_QUEUE_PRIO_NUM];
+		} priority;
 	} queue;
 
 	struct {

--- a/src/em_mem.h
+++ b/src/em_mem.h
@@ -136,6 +136,13 @@ typedef struct {
 	env_atomic32_t pool_count;
 	/** libconfig setting, default (compiled) and runtime (from file) */
 	libconfig_t libconfig;
+	/** priority mapping */
+	struct {
+		/** mapping table */
+		int map[EM_QUEUE_PRIO_NUM];
+		int num_runtime;
+	} queue_prio;
+
 	/** Guarantee that size is a multiple of cache line size */
 	void *end[0] ENV_CACHE_LINE_ALIGNED;
 } em_shm_t;

--- a/src/em_pool_types.h
+++ b/src/em_pool_types.h
@@ -73,10 +73,30 @@ typedef struct {
 } mpool_statistics_t ENV_CACHE_LINE_ALIGNED;
 
 /**
+ * @def POOL_ODP2EM_TBL_LEN
+ * Length of the mpool_tbl_t::pool_odp2em[] array
+ */
+#define POOL_ODP2EM_TBL_LEN  256
+/*
+ * Verify at compile time that the mpool_tbl_t::pool_odp2em[] mapping table
+ * is large enough.
+ * Verified also at runtime that: POOL_ODP2EM_TBL_LEN > odp_pool_max_index()
+ */
+COMPILE_TIME_ASSERT(EM_CONFIG_POOLS * EM_MAX_SUBPOOLS <= POOL_ODP2EM_TBL_LEN,
+		    "MPOOL_TBL_T__POOL_ODP2EM__LEN_ERR");
+
+/**
  * EM pool element table
  */
 typedef struct {
+	/** event/memory pool elem table */
 	mpool_elem_t pool[EM_CONFIG_POOLS];
+
+	/**
+	 * Mapping from odp_pool_index(odp_pool) to em-pool handle.
+	 * Verified at runtime that: POOL_ODP2EM_TBL_LEN > odp_pool_max_index()
+	 */
+	em_pool_t pool_odp2em[POOL_ODP2EM_TBL_LEN] ENV_CACHE_LINE_ALIGNED;
 
 	/** Pool usage statistics - updated per EM-core */
 	mpool_statistics_t pool_stat_core[EM_MAX_CORES] ENV_CACHE_LINE_ALIGNED;

--- a/src/em_queue.h
+++ b/src/em_queue.h
@@ -257,23 +257,11 @@ list_node_to_queue_elem(const list_node_t *const list_node)
 static inline int
 prio_em2odp(em_queue_prio_t em_prio, odp_schedule_prio_t *odp_prio /*out*/)
 {
-	switch (em_prio) {
-	case EM_QUEUE_PRIO_LOWEST:
-		/* fallthrough */
-	case EM_QUEUE_PRIO_LOW:
-		*odp_prio = odp_schedule_min_prio();
+	if (em_prio < EM_QUEUE_PRIO_NUM) {
+		*odp_prio = em_shm->queue_prio.map[em_prio];
 		return 0;
-	case EM_QUEUE_PRIO_NORMAL:
-		*odp_prio = odp_schedule_default_prio();
-		return 0;
-	case EM_QUEUE_PRIO_HIGH:
-		/* fallthrough */
-	case EM_QUEUE_PRIO_HIGHEST:
-		*odp_prio = odp_schedule_max_prio();
-		return 0;
-	default:
-		return -1;
 	}
+	return -1;
 }
 
 static inline int
@@ -329,7 +317,7 @@ local_queue_dequeue(void)
 	if (locm->local_queues.empty)
 		return NULL;
 
-	prio = EM_QUEUE_PRIO_HIGHEST;
+	prio = EM_QUEUE_PRIO_NUM - 1;
 	for (i = 0; i < EM_QUEUE_PRIO_NUM; i++) {
 		/* from hi to lo prio: next prio if local queue is empty */
 		if (locm->local_queues.prio[prio].empty_prio) {
@@ -369,7 +357,7 @@ next_local_queue_events(em_event_t ev_tbl[/*out*/], int num_events)
 	odp_queue_t local_queue;
 	int num;
 
-	prio = EM_QUEUE_PRIO_HIGHEST;
+	prio = EM_QUEUE_PRIO_NUM - 1;
 	for (int i = 0; i < EM_QUEUE_PRIO_NUM; i++) {
 		/* from hi to lo prio: next prio if local queue is empty */
 		if (locm->local_queues.prio[prio].empty_prio) {

--- a/src/em_queue_types.h
+++ b/src/em_queue_types.h
@@ -246,10 +246,6 @@ typedef struct local_queues_t {
 	} prio[EM_QUEUE_PRIO_NUM];
 } local_queues_t;
 
-/* Assert that local queue prio[x] accesses from hi -> lo are ok */
-COMPILE_TIME_ASSERT(EM_QUEUE_PRIO_HIGHEST - EM_QUEUE_PRIO_NUM + 1 ==
-		    EM_QUEUE_PRIO_LOWEST, LOCAL_QUEUE_PRIO_ARRAY_ERROR);
-
 /**
  * Track output-queues used during a dispatch round (burst)
  */

--- a/src/event_machine_queue.c
+++ b/src/event_machine_queue.c
@@ -383,3 +383,17 @@ error:
 		       queue, iq.device_id, iq.queue_id);
 	return queue_idx % EM_MAX_QUEUES;
 }
+
+int em_queue_get_num_prio(int *num_runtime)
+{
+	if (EM_CHECK_LEVEL > 1 && unlikely(em_shm == NULL)) {
+		INTERNAL_ERROR(EM_ERR_NOT_INITIALIZED,
+			       EM_ESCOPE_QUEUE_GET_NUM_PRIO,
+			       "EM not initialized!");
+		return 0;
+	}
+	if (num_runtime != NULL)
+		*num_runtime = em_shm->queue_prio.num_runtime;
+
+	return EM_QUEUE_PRIO_NUM;
+}


### PR DESCRIPTION
Event Machine on ODP v2.6.0

- Support for EM API v2.6 (em-odp/include), see API changes in
  em-odp/include/event_machine/README_API.
  * New APIs for Timer, Event, Queue, Extension-APIs *

- New configure script option (see em-odp/configure.ac):
  '--enable-debug-print' that enables EM debug printouts via the EM_DBG() macro:
        em-odp/build $> ../configure --prefix=… --enable-debug-print
  Currently if enabled, will print event header layout information at startup
  as well as EM timer runtime debug info.

- EM config file options - config/em-odp.conf:
 - Config file version bumped to "0.0.9" (user config files need to be updated!)
 - Options for setting EM Queue priority-levels:
   a) Option 'queue.priority.map_mode':
     Select the queue priority mapping mode, i.e how to map EM queue priorities
     to ODP scheduled queue priorities.
     0: legacy simple mode, map EM prios to ODP min/default/max prio-levels only
        (0 is the default mode)
     1: map according to the ODP runtime number of priorities
        (linear fit to full range of ODP prio-levels)
     2: custom mapping
        (use 'custom_map' below)
   b) Option 'queue.priority.custom_map':
     Custom priority map (required when 'queue.priority.map_mode = 2')
     This array needs to have EM_QUEUE_PRIO_NUM entries (typically 8).
     The first entry is for the lowest priority (0). The value is ADDED to
     odp_schedule_min_prio() and then passed to ODP, i.e. values are offsets
     from odp_schedule_min_prio(). Values given here must be valid for ODP
     runtime configuration, i.e. value plus odp_schedule_min_prio() must
     not exceed odp_schedule_max_prio().
     Example of a custom priority mapping:
        queue: {
                priority: {
                        map_mode = 2
                        custom_map = [0, 0, 1, 3 ,4 ,6 ,7, 7]
                }
        }

- EM SW ISA printout added at start-up:
    ...
    ===========================================================
    EM Info on target: em-odp
    ===========================================================
    EM API version:         v2.6, 64 bit (EM_CHECK_LEVEL:3, EM_ESV_ENABLE:1)
    EM build info:          v2.6.0 2021-10-15 16:46
    ODP API version:        1.32.0
    ODP impl name:          odp-linux
    ODP impl details:       odp-linux 1.32.0-0 (v1.32.0) 1.32.0.0
    CPU model:              Intel(R) Xeon(R) CPU E5-2697 v3
    CPU arch:               x86     // ARM etc.
    CPU ISA version:        Unknown // ARMv8.2-A  # HW detected, reported by ODP
     SW ISA version (ODP):  x86_64  // ARMv8.1-A  # ODP SW config (compile time)
     SW ISA version (EM):   x86_64  // ARMv8.1-A  #  EM SW config (compile time)

  Arch specific CFLAGS should be passed to EM and ODP via configure.
  Example for a made up ARMv8 SoC called "soc-x":
  odp-soc-x/build> ../configure … --with-platform=soc-x [default=linux-generic]
     em-odp/build> ../configure … CFLAGS=”-march=armv8.2-a+… -mcpu=soc-x”
  The whole chain of used SW libs/dependencies should preferably be compiled
  with the same -march/-mcpu options for best results:
    other-libs/build> ../configure … CFLAGS=”-march=armv8.2-a+… -mcpu=soc-x”

- Program termination: flush the scheduler in em_term_core() on each EM-core.
  Move the flushing of scheduled events from em_term() to em_term_core() so that
  all participating EM-cores do it.
  See example usage of in em-odp/programs/common/cm_setup.c:
  ('thread' in the description below refers to odph_thread_t that can be either
   linux processes or threads)
  em_term() has been moved from each EM-core's run-function to the common thread
  that created the EM-core threads. The common thread waits for the created
  EM-core threads to return/join.
  After each EM-core has paused and flushed the scheduler from core-local events
  (by calling em_term_local()) they terminate by "joining" back into the common
  thread, which calls em_term() once to terminate EM (and ODP) before exiting
  the application.

- Fixes:
  - queue group: fix: em_queue_group_modify_sync() incorrectly removed the
                      calling core
  - ESV: fix: usr2em-revert transition to handle evgen wrap correctly
    Event State Verification (ESV) incorrectly handled the revert of a usr-to-EM
    transition when the counter wrapped.

- Example programs (em-odp/programs)
  - Common Setup (cm_setup.c&h):
    - Move the flushing of scheduled events from em_term() to em_term_core().
      Descibed above in "Program termination".
  - Packet-IO setup (cm_pktio.c&h)
    - Add command-line option to select whether to use an
      1) ODP-packet-pool: -o, --pktpool-odp
         or an
      2) EM event-pool: -e, --pktpool-em (default if no option given)
      as the main event pool to be used by packet-io for received packets.
      Packet-IO is implemented via ODP so an EM event-pool needs to be converted
      to the corresponding ODP packet-pools with the new extension API
      'em_odp_pool2odp()'. Using an EM pool, instead of directly using an
      ODP pool, allows for more thorough ESV-checking also for packet-IO when
      em-odp.conf: esv.prealloc_pools = true.
  - Timer
  - Misc. performance and bug fixes in the example applications

- Tested against
  odp-linux - https://github.com/OpenDataPlane/odp
    Commit: 69f27643ec2287875048314d7975f0de4bcbbfa4 [69f2764]
    Date: Friday, 1 October 2021 18:12.09
    Commit Date: Tuesday, 12 October 2021 17:06.16
    configure.ac: move project to C standard revision 11
  odp-dpdk - https://github.com/OpenDataPlane/odp-dpdk
    Commit: 50c7b605b97474d26fcf600b4061968e3543b45b [50c7b60]
    Date: Monday, 11 October 2021 16:37.51
    Merge ODP v1.32.0.0