### PR TITLE
ci: github-pages: fix error "TARGET_ARCH: unbound variable"

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - master
 
+env:
+  CC: gcc
+  # Default target architecture for native compilation
+  TARGET_ARCH: ""
+
 jobs:
   Documentation:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Fix error "TARGET_ARCH: unbound variable" in CI workflow Github Pages.