### PR TITLE
Fix indent in pktio_close

### DIFF
--- a/programs/common/cm_pktio.c
+++ b/programs/common/cm_pktio.c
@@ -674,10 +674,11 @@ void pktio_close(void)
 		odp_pktio_t pktio = pktio_shm->ifs.pktio_hdl[if_idx];
 		int ret = odp_pktio_close(pktio);
 
-		if (unlikely(ret != 0))
+		if (unlikely(ret != 0)) {
 			APPL_EXIT_FAILURE("pktio close failed for if:%d",
 					  if_idx);
-			pktio_shm->ifs.pktio_hdl[if_idx] = ODP_PKTIO_INVALID;
+		}
+		pktio_shm->ifs.pktio_hdl[if_idx] = ODP_PKTIO_INVALID;
 	}
 
 	pktin_queue_queueing_destroy();


### PR DESCRIPTION
This 'if' clause does not guard via braces, the latter line is
indented as if it were guarded by the 'if'.