### PR TITLE
robot-tests: move robot tests from ci repo

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -58,16 +58,10 @@ jobs:
         sudo apt-get update
         sudo apt-get install libconfig-dev
         sudo pip3 install robotframework
+        sudo apt-get install libcli-dev
+        sudo apt-get install telnet
     - name: Checkout EM-ODP
       uses: actions/checkout@v2
-    # Checkout ci for robot files
-    - name: Checkout ci
-      uses: actions/checkout@v2
-      with:
-        repository: ${{ github.repository_owner }}/ci
-        clean: false
-        path: ci
-        ref: master
     - name: Build EM-ODP
       run: ./scripts/build.sh
     - name: Run Robot Tests

--- a/robot-tests/README.md
+++ b/robot-tests/README.md
@@ -1,0 +1,16 @@
+# Nokia: Event Machine Robot Tests
+
+## Install robotframework in Ubuntu
+
+```bash
+sudo apt install python3-pip
+sudo pip3 install robotframework
+```
+
+## Manually run individual robot tests
+
+```bash
+robot --variable APPLICATION:<path_to_application>/<application> --variable CORE_MASK:<core_mask> --variable APPLICATION_MODE:<t/p> <path_to_robot_files>/<application>.robot
+e.g
+$ robot --variable APPLICATION:/home/username/EM/em-odp/build/programs/example/hello/hello --variable CORE_MASK:0xFE --variable APPLICATION_MODE:t /home/username/EM/em-odp/robot-tests/example/hello.robot
+```

--- a/robot-tests/common.resource
+++ b/robot-tests/common.resource
@@ -1,0 +1,94 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Resource file
+Library    Collections
+Library    Process
+Library    String
+
+
+*** Variables ***
+${KILL_TIMEOUT} =    30s
+
+# Match Pool Statistics
+@{POOL_STATISTICS_MATCH} =
+...    (buf|pkt)(\\s*[0-9]+)+(\\s*[0-3]+:\\[sz=[0-9]+\\s*n=[0-9]+\\(0/[0-9]+\\)\\s*\\$=[0-9]+\\])+
+
+# List of eligible return codes
+# The return code seem to depend on the version of the used robot framework.
+# Terminating a test with Ctrl-C sometimes returned 0, sometimes SIGINT(-2).
+# Timeout should return SIGKILL(-9) but not always. Since most of our programs
+# keeps running once started, our robot tests send SIGINT to the programs after
+# running them for a while or SIGKILL on timeout. So all of the return code 0,
+# -2(SIGINT) and -9(SIGKILL) can be considered as eligible.
+@{RC_LIST} =    ${0}    ${-2}    ${-9}
+
+# Regex pattern that must not be matched by all test cases
+@{REGEX_NOT_MATCH} =    EM ERROR
+
+# Common arguments used for all test cases
+@{CM_ARGS} =    -c    ${CORE_MASK}    -${APPLICATION_MODE}
+
+
+*** Keywords ***
+Kill Any Hanging Applications
+    [Documentation]    Kill any hanging applications
+    Terminate All Processes    kill=true
+
+Run EM-ODP Test
+    [Documentation]    Run em-odp application in the background, send SIGINT
+    ...    signal to the application process after sleeping the given sleep_time,
+    ...    then wait for the application to be completed or killed and check if
+    ...    the return code matches any of the eligible codes in RC_LIST and stdout
+    ...    matches given regex_match.
+
+    # sleep_time: sleep time (in seconds) before sending SIGINT to the em-odp application
+    # regex_match: regex pattern that must be matched
+    [Arguments]    ${sleep_time}    ${regex_match}
+
+    # In order to start application log from a new line
+    Log To Console    \n
+
+    # Run application with given arguments
+    ${app_handle} =    Process.Start Process    ${APPLICATION}
+    ...    @{CM_ARGS}
+    ...    stderr=STDOUT
+    ...    shell=True
+    ...    stdout=${TEMPDIR}/stdout.txt
+
+    IF    ${sleep_time}
+        # Sleep ${sleep_time} seconds
+        Sleep    ${sleep_time}
+        Send Signal To Process    SIGINT    ${app_handle}    group=true
+    END
+
+    ${output} =    Process.Wait For Process
+    ...    handle=${app_handle}
+    ...    timeout=${KILL_TIMEOUT}
+    ...    on_timeout=kill
+
+    # Log output
+    Log    ${output.stdout}    console=yes
+
+    # Verify the return code matches any of the eligible code in RC_LIST
+    List Should Contain Value
+    ...    ${RC_LIST}
+    ...    ${output.rc}
+    ...    Application Return Code: ${output.rc}
+
+    # Match regular expression lines
+    FOR    ${line}    IN    @{regex_match}
+        Should Match Regexp    ${output.stdout}    ${line}
+    END
+
+    FOR    ${line}    IN    @{REGEX_NOT_MATCH}
+        Should Not Match Regexp    ${output.stdout}    ${line}
+    END
+
+    FOR    ${line}    IN    @{POOL_STATISTICS_MATCH}
+        Should Match Regexp    ${output.stdout}    ${line}
+    END

--- a/robot-tests/example/api_hooks.robot
+++ b/robot-tests/example/api_hooks.robot
@@ -1,0 +1,34 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation     Test api_hooks -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource          ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+# Regex pattern that must be matched by all the test cases
+@{REGEX_MATCH} =
+...    Dispatch enter callback
+...    Alloc-hook
+...    Free-hook
+...    Send-hook
+...    Done\\s*-\\s*exit
+
+# Regex pattern that must not be matched by all the test cases
+@{REGEX_NOT_MATCH} =
+...    EM ERROR
+...    failed!
+
+
+*** Test Cases ***
+Test api_hooks -c ${CORE_MASK} -${APPLICATION_MODE}
+    [Documentation]    api_hooks -c ${CORE_MASK} -${APPLICATION_MODE}
+    [Tags]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=30    regex_match=${REGEX_MATCH}

--- a/robot-tests/example/dispatcher_callback.robot
+++ b/robot-tests/example/dispatcher_callback.robot
@@ -1,0 +1,37 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Dispatcher Callback -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+# Common arguments used for all test cases
+${FIRST_REGEX} =    SEPARATOR=
+...    Dispatcher\\s*enter\\s*callback\\s*[1-2]+\\s*for\\s*EO:\\s*0x[a-fA-F0-9]+
+...    \\s*\\(EO\\s*[A-B]+\\)\\s*Queue:\\s*0x[a-fA-F0-9]+\\s*on\\s*core\\
+...    s*[0-9]+\\.\\s*Event\\s*seq:\\s*[0-9]+\\.
+
+${SECOND_REGEX} =    SEPARATOR=
+...    Ping\\s*from\\s*EO\\s*[A-B]+!\\s*Queue:\\s*0x[a-fA-f0-9]+\\s*on\\s*core
+...    \\s*[0-9]+\\.\\s*Event\\s*seq:\\s*[0-9]+\\.
+
+@{REGEX_MATCH} =
+...    ${FIRST_REGEX}
+...    ${SECOND_REGEX}
+...    Dispatcher\\s*exit\\s*callback\\s*[1-2]+\\s*for\\s*EO:\\s*0x[a-fA-f0-9]+
+...    Done\\s*-\\s*exit
+
+
+*** Test Cases ***
+Test Dispatcher Callback
+    [Documentation]    dispatcher_callback -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=30    regex_match=${REGEX_MATCH}

--- a/robot-tests/example/emcli.robot
+++ b/robot-tests/example/emcli.robot
@@ -1,0 +1,89 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test EM CLI(Command Line Interface) with hello application
+Resource    ../common.resource
+Library           Telnet
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+@{REGEX_MATCH} =
+...    cli\\.enable: true\\(1\\)
+...    Starting CLI server on 127\\.0\\.0\\.1:55555
+...    CLI server terminated!
+...    Done\\s*-\\s*exit
+
+@{TELNET_REGEX} =
+...    Commands available:
+...    call\\s+odp_cls_print_all
+...    em_info_print\\s+[Name: all|cpu_arch|conf|help]
+...    em_core_print\\s+[Name: map|help]
+
+
+*** Test Cases ***
+Test Emcli
+    [Documentation]    hello -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${core_mask}    ${application_mode}
+
+    # In order to start application log from a new line
+    Log To Console    \n
+
+    # Run hello application with given arguments
+    ${app_handle} =    Process.Start Process    ${APPLICATION}
+    ...    @{CM_ARGS}
+    ...    stderr=STDOUT
+    ...    shell=True
+    ...    stdout=${TEMPDIR}/stdout.txt
+
+    Sleep    6s
+    Process Should Be Running    ${app_handle}
+
+    # Open telnet connection
+    Open Connection    localhost     port=55555
+    Write    help
+    # . normally will not match a newline, use (?s) to make . to match a newline
+    ${telnet_out} =    Read Until Regexp    (?s)EM-ODP>(.*?)EM-ODP>
+    Close All Connections
+
+    Send Signal To Process    SIGINT    ${app_handle}    group=true
+
+    ${output} =    Process.Wait For Process
+    ...    handle=${app_handle}
+    ...    timeout=${KILL_TIMEOUT}
+    ...    on_timeout=kill
+
+    # Log output
+    Log To Console    \n
+    Log    ${output.stdout}    console=yes
+    Log To Console    \nTelnet client output:\n    # To seperate the two logs
+    Log    ${telnet_out}    console=yes
+
+    # Verify the return code matches any of the eligible code in RC_LIST
+    List Should Contain Value
+    ...    ${RC_LIST}
+    ...    ${output.rc}
+    ...    Application Return Code: ${output.rc}
+
+    # Match telnet client outputs
+    FOR    ${line}    IN    @{TELNET_REGEX}
+        Should Match Regexp    ${telnet_out}    ${line}
+    END
+
+    # Match em-app outputs with REGEX_MATCH
+    FOR    ${line}    IN    @{REGEX_MATCH}
+        Should Match Regexp    ${output.stdout}    ${line}
+    END
+
+    FOR    ${line}    IN    @{REGEX_NOT_MATCH}
+        Should Not Match Regexp    ${output.stdout}    ${line}
+    END
+
+    FOR    ${line}    IN    @{POOL_STATISTICS_MATCH}
+        Should Match Regexp    ${output.stdout}    ${line}
+    END

--- a/robot-tests/example/error.robot
+++ b/robot-tests/example/error.robot
@@ -1,0 +1,34 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Error -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup    Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+${FOUTH_REGEX} =    SEPARATOR=
+...    Appl\\s*EO\\s*specific\\s*error\\s*handler:\\s*EO\\s*0x[a-fA-Z0-9]+\\s*error
+...    \\s*0x[a-fA-Z0-9]+\\s*escope\\s*0x[a-fA-Z0-9]+
+
+@{REGEX_MATCH} =
+...    EM\\s*ERROR:0x[a-fA-Z0-9]+\\s*ESCOPE:0x[a-fA-Z0-9]+\\s*EO:0x[a-fA-Z0-9]+-"EO\\s*[A-fA-F]+"
+...    core:[0-9]+\\s*ecount:[0-9]+\\([0-9]+\\)\\s*event_machine_event.c:[0-9]+\\s*em_free\\(\\)
+...    Error\\s*log\\s*from\\s*EO\\s*[a-fA-Z]+\\s*\\[[0-9]+\\]\\s*on\\s*core\\s*[0-9]+!
+...    ${FOUTH_REGEX}
+...    Done\\s*-\\s*exit
+
+@{REGEX_NOT_MATCH} =    NO ERROR
+
+
+*** Test Cases ***
+Test Error
+    [Documentation]    error -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=25    regex_match=${REGEX_MATCH}

--- a/robot-tests/example/event_group.robot
+++ b/robot-tests/example/event_group.robot
@@ -1,0 +1,27 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Event Group -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+@{REGEX_MATCH} =
+...    Start\\s*event\\s*group
+...    Event\\s*group\\s*notification\\s*event\\s*received\\s*after\\s*256\\s*data\\s*events\\.
+...    Cycles\\s*curr:[0-9]+,\\s*ave:[0-9]+
+...    Done\\s*-\\s*exit
+
+
+*** Test Cases ***
+Test Event Group
+    [Documentation]    event_group -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=30    regex_match=${REGEX_MATCH}

--- a/robot-tests/example/event_group_abort.robot
+++ b/robot-tests/example/event_group_abort.robot
@@ -1,0 +1,33 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Event Group Abort -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+@{REGEX_MATCH}    Entering the event dispatch loop
+...    Round [0-9]+
+...    Created\\s*[0-9]+\\s*event\\s*group\\(s\\)\\s*with\\s*count\\s*of\\s*[0-9]+
+...    Abort\\s*group\\s*when\\s*received\\s*[0-9]+\\s*events
+...    Evgrp\\s*events:\\s*Valid:[0-9]+\\s*Expired:[0-9]+
+...    Evgrp\\s*increments:\\s*Valid:[0-9]+\\s*Failed:[0-9]+
+...    Evgrp\\s*assigns:\\s*Valid:[0-9]+\\s*Failed:[0-9]+
+...    Aborted\\s*[0-9]+\\s*event\\s*groups
+...    Failed\\s*to\\s*abort\\s*[0-9]+\\s*times
+...    Received\\s*[0-9]+\\s*notification\\s*events
+...    Freed\\s*[0-9]+\\s*notification\\s*events
+
+
+*** Test Cases ***
+Test Event Group Abort
+    [Documentation]    event_group_abort -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=30    regex_match=${REGEX_MATCH}

--- a/robot-tests/example/event_group_assign_end.robot
+++ b/robot-tests/example/event_group_assign_end.robot
@@ -1,0 +1,39 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Event Group Assign End -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+${THIRD_REGEX} =    SEPARATOR=
+...    Assigned\\s*event\\s*group\\s*notification\\s*event\\s*received\\s*after
+...    \\s*[0-9]+\\s*data\\s*events\\.
+
+${FIFTH_REGEX} =    SEPARATOR=
+...    "Normal"\\s*event\\s*group\\s*notification\\s*event\\s*received\\s*after
+...    \\s*2048\\s*data\\s*events\\.
+
+@{REGEX_MATCH} =
+...    Start\\s*event\\s*group
+...    Start\\s*assigned\\s*event\\s*group\\s*
+...    ${THIRD_REGEX}
+...    Cycles\\s*curr:[0-9]+,\\s*ave:[0-9]+
+...    ${FIFTH_REGEX}
+...    Cycles\\s*curr:[0-9]+,\\s*ave:[0-9]+
+...    Chained\\s*event\\s*group\\s*done
+...    Done\\s*-\\s*exit
+
+
+*** Test Cases ***
+Test Event Group Assign End
+    [Documentation]    event_group_assign_end -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=30    regex_match=${REGEX_MATCH}

--- a/robot-tests/example/event_group_chaining.robot
+++ b/robot-tests/example/event_group_chaining.robot
@@ -1,0 +1,28 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Event Group Chaining -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+@{REGEX_MATCH} =
+...    Start\\s*event\\s*group
+...    Event\\s*group\\s*notification\\s*event\\s*received\\s*after\\s*[0-9]+\\s*data\\s*events\\.
+...    Cycles\\s*curr:[0-9]+,\\s*ave:[0-9]+
+...    Event\\s*group\\s*notification\\s*event\\s*received\\s*after\\s*[0-9]+\\s*data\\s*events\\.
+...    Chained\\s*event\\s*group\\s*done
+
+
+*** Test Cases ***
+Test Event Group Chaining
+    [Documentation]    event_group_chaining -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=30    regex_match=${REGEX_MATCH}

--- a/robot-tests/example/fractal.robot
+++ b/robot-tests/example/fractal.robot
@@ -1,0 +1,27 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Fractal -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+@{REGEX_MATCH} =
+...    Started\\s*Pixel\\s*handler\\s*-\\s*EO:0x[a-fA-F0-9]+\\.\\s*Q:0x[a-fA-F0-9]+\\.
+...    Started\\s*Worker\\s*-\\s*EO:0x[a-fA-f0-9]+\\.\\s*Q:0x[a-fA-F0-9]+\\.
+...    Started\\s*Imager\\s*-\\s*EO:0x[a-fA-f0-9]+\\.\\s*Q:0x[a-fA-f0-9]+\\.
+...    Frames\\s*per\\s*second:\\s*[0-9]+\\s*|\\s*frames\\s*[0-9]+\\s*-\\s*[0-9]+
+
+
+*** Test Cases ***
+Test Fractal
+    [Documentation]    fractal -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=30    regex_match=${REGEX_MATCH}

--- a/robot-tests/example/hello.robot
+++ b/robot-tests/example/hello.robot
@@ -1,0 +1,29 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Hello -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+${FIRST_REGEX} =    SEPARATOR=
+...    Hello world from EO [AB]\!\\s+My queue is 0x[0-9|A-F|a-f]+.\\s+I'm on co
+...    re [0-9]+.\\s+Event seq is [0-9]+.
+
+@{REGEX_MATCH} =
+...    ${FIRST_REGEX}
+...    Done\\s*-\\s*exit
+
+
+*** Test Cases ***
+Test Hello
+    [Documentation]    hello -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=30    regex_match=${REGEX_MATCH}

--- a/robot-tests/example/ordered.robot
+++ b/robot-tests/example/ordered.robot
@@ -1,0 +1,29 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Ordered -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+${FIRST_REGEX} =    SEPARATOR=
+...    cycles\\s*per\\s*event\\s*[0-9]+\\.[0-9]+\\s*@[0-9]+\\.[0-9]+\\s*MHz\\s*
+...    \\(core-[0-9]+\\s*[0-9]+\\)
+
+@{REGEX_MATCH} =
+...    ${FIRST_REGEX}
+...    Done\\s*-\\s*exit
+
+
+*** Test Cases ***
+Test Ordered
+    [Documentation]    ordered -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=30    regex_match=${REGEX_MATCH}

--- a/robot-tests/example/queue_group.robot
+++ b/robot-tests/example/queue_group.robot
@@ -1,0 +1,40 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Queue Group -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+${FIRST_REGEX} =    SEPARATOR=
+...    Created\\s*test\\s*queue:0x[a-fA-F0-9]+\\s*type:[A-Z]+\\([0-9]+\\)\\s*
+...    queue\\s*group:0x[a-fA-F0-9]+\\s*\\(name:"[a-zA-Z0-9]+"\\)
+
+${SEVENTH_REGEX} =    SEPARATOR=
+...    Deleting\\s*test\\s*queue:0x[a-fA-F0-9]+,\\s*Qgrp\\s*ID:0x[a-fA-F0-9]+
+...    \\s*\\(name:"[a-zA-Z0-9]+"\\)
+
+@{REGEX_MATCH} =
+...    ${FIRST_REGEX}
+...    Received\\s*[0-9]+\\s*events\\s*on\\s*Q:0x[a-fA-F0-9]+:
+...    QueueGroup:0x[a-fA-F0-9]+,\\s*Curr\\s*Coremask:0x[a-fA-F0-9]+
+...    Now\\s*Modifying:
+...    QueueGroup:0x[a-fA-F0-9]+,\\s*New\\s*Coremask:0x[a-fA-F0-9]+
+...    All\\s*cores\\s*removed\\s*from\\s*QueueGroup!
+...    ${SEVENTH_REGEX}
+...    !!!\\s*Restarting\\s*test\\s*!!!
+...    Done\\s*-\\s*exit
+
+
+*** Test Cases ***
+Test Queue Group
+    [Documentation]    queue_group -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=50    regex_match=${REGEX_MATCH}

--- a/robot-tests/example/queue_types_ag.robot
+++ b/robot-tests/example/queue_types_ag.robot
@@ -1,0 +1,31 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Queues Types AG -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+${FIRST_REGEX} =    SEPARATOR=
+...    Stat\\s*Core-[0-9]+:\\s*Count/PairType\\s*A-A:\\s*[0-9]+\\s*P-P:\\s*[0-9]+
+...    \\s*PO-PO:\\s*[0-9]+\\s*P-A:\\s*[0-9]+\\s*PO-A:\\s*[0-9]+\\s*PO-P:\\s*[0-9]
+...    +\\s*AG-AG:\\s*[0-9]+\\s*AG-A:\\s*[0-9]+\\s*AG-P:\\s*[0-9]+\\s*AG-PO:\\s*
+...    [0-9]+\\s*cycles/event:[0-9]+\\s*@[0-9]+MHz\\s*[0-9]+
+
+@{REGEX_MATCH} =
+...    ${FIRST_REGEX}
+...    Done\\s*-\\s*exit
+
+
+*** Test Cases ***
+Test Queue Types AG
+    [Documentation]    queues_types_ag -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=60    regex_match=${REGEX_MATCH}

--- a/robot-tests/example/queue_types_local.robot
+++ b/robot-tests/example/queue_types_local.robot
@@ -1,0 +1,46 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Queue Types Local -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+${FIRST_REGEX} =    SEPARATOR=
+...    EO\\s*0x[a-fA-F0-9]+\\s*starting\\s*EO-locq\\s*0x[0-9]+\\s*starting\\s*New
+...    \\s*atomic\\s*group:group_[a-zA-Z]+\\s*for\\s*EO:\\s*0x[a-fA-F0-9]+
+
+${SECOND_REGEX} =    SEPARATOR=
+...    EO-locq\\s*0x[a-fA-F0-9]+\\s*starting\\s*New\\s*atomic\\s*group:group_[a-zA-Z]
+...    +\\s*for\\s*EO:\\s*0x[a-fA-F0-9]+
+
+${THIRD_REGEX} =    SEPARATOR=
+...    EO\\s*0x[a-fA-F0-9]+\\s*starting\\s*EO-locq\\s*0x[a-fA-F0-9]+\\s*starting
+...    \\s*EO\\s*0x[a-fA-F0-9]+\\s*starting
+
+${FOURTH_REGEX} =    SEPARATOR=
+...    Core-[0-9]+:\\s*A-L-A-L:\\s*[0-9]+\\s*P-L-P-L:\\s*[0-9]+\\s*PO-L-PO-L:\\s*
+...    [0-9]+\\s*P-L-A-L:\\s*[0-9]+\\s*PO-L-A-L:\\s*[0-9]+\\s*PO-L-P-L:\\s*[0-9]+
+...    \\s*AG-L-AG-L:\\s*[0-9]+\\s*AG-L-A-L:\\s*[0-9]+\\s*AG-L-P-L:\\s*[0-9]+\\s*
+...    AG-L-PO-L:\\s*[0-9]+\\s*cycles/event:[0-9]+\\s*@[0-9]+MHz\\s*[0-9]+
+
+@{REGEX_MATCH} =
+...    ${FIRST_REGEX}
+...    ${SECOND_REGEX}
+...    ${THIRD_REGEX}
+...    ${FOURTH_REGEX}
+...    Done\\s*-\\s*exit
+
+
+*** Test Cases ***
+Test Queue Types Local
+    [Documentation]    queue_types_local -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=60    regex_match=${REGEX_MATCH}

--- a/robot-tests/example/timer_hello.robot
+++ b/robot-tests/example/timer_hello.robot
@@ -1,0 +1,30 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Timer Hello -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+@{REGEX_MATCH} =
+...    EO *
+...    System has [0-9]+ timer
+...    EO local start
+...    [0-9]+\. tick
+...    tock
+...    Meditation time.
+...    Done\\s*-\\s*exit
+
+
+*** Test Cases ***
+Test Timer Hello
+    [Documentation]    timer_hello -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=120    regex_match=${REGEX_MATCH}

--- a/robot-tests/example/timer_test.robot
+++ b/robot-tests/example/timer_test.robot
@@ -1,0 +1,45 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Timer -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+@{REGEX_MATCH} =
+...    EO *
+...    Timer\: Creating [0-9]+ timeouts took [0-9]+ ns \\([0-9]+ ns each\\)
+...    Linux\: Creating [0-9]+ timeouts took [0-9]+ ns \\([0-9]+ ns each\\)
+...    Running
+...    Heartbeat count [0-9]+
+...    ONESHOT\:
+...    Received: [0-9]+
+...    Cancelled\: [0-9]+
+...    Cancel failed \\(too late\\)\: [0-9]+
+...    SUMMARY/TICKS: min [0-9]+, max [0-9]+, avg [0-9]+
+...    /[A-Z]S: min [0-9]+, max [0-9]+, avg [0-9]+
+...    SUMMARY/LINUX [A-Z]S: min -?[0-9]+, max -?[0-9]+, avg -?[0-9]+
+...    PERIODIC\:
+...    Received\: [0-9]+
+...    Cancelled\: [0-9]+
+...    Cancel failed \\(too late\\)\: [0-9]+
+...    Errors\: [0-9]+
+...    TOTAL RUNTIME/[A-Z]S\: min [0-9]+, max [0-9]+
+...    Cleaning up
+...    Timer\: Deleting [0-9]+ timeouts took [0-9]+ ns \\([0-9]+ ns each\\)
+...    Linux\: Deleting [0-9]+ timeouts took [0-9]+ ns \\([0-9]+ ns each\\)
+...    Done\\s*-\\s*exit
+
+
+*** Test Cases ***
+Test Timer
+    [Documentation]    timer -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=90    regex_match=${REGEX_MATCH}

--- a/robot-tests/performance/atomic_processing_end.robot
+++ b/robot-tests/performance/atomic_processing_end.robot
@@ -1,0 +1,37 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Atomic Processing End -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+${FIRST_REGEX} =    SEPARATOR=
+...    normal atomic processing:\\s*[0-9]+\\s*cycles/event\\s*events/s:[0-9]+\\.
+...    [0-9]+\\s*M\\s*@[0-9]+\\.[0-9]+\\s*MHz\\s*\\(core-[0-9]+\\s*[0-9]+\\)
+
+${SECOND_REGEX} =    SEPARATOR=
+...    em_atomic_processing_end\\(\\):\\s*[0-9]+\\s*cycles/event\\s*events/s:[0-9]
+...    +\\.[0-9]+\\s*M\\s*@[0-9]+.[0-9]+\\s*MHz\\s*\\(core-[0-9]+\\s*[0-9]+\\)
+
+@{REGEX_MATCH} =
+...    ${FIRST_REGEX}
+...    ${SECOND_REGEX}
+...    Done\\s*-\\s*exit
+
+@{REGEX_NOT_MATCH} =
+...    EM ERROR
+
+
+*** Test Cases ***
+Test Atomic Processing End
+    [Documentation]    atomic_processing_end -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=60    regex_match=${REGEX_MATCH}

--- a/robot-tests/performance/loop.robot
+++ b/robot-tests/performance/loop.robot
@@ -1,0 +1,29 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Loop -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+${FIRST_REGEX} =    SEPARATOR=
+...    cycles/event:\\s*[0-9]+\\.[0-9]+\\s*Mevents/s/core:\\s*[0-9]+\\.[0-9]+
+...    \\s*[0-9]+\\s*MHz\\s*core[0-9]+\\s*[0-9]+
+
+@{REGEX_MATCH} =
+...    ${FIRST_REGEX}
+...    Done\\s*-\\s*exit
+
+
+*** Test Cases ***
+Test Loop
+    [Documentation]    loop -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=40    regex_match=${REGEX_MATCH}

--- a/robot-tests/performance/loop_multircv.robot
+++ b/robot-tests/performance/loop_multircv.robot
@@ -1,0 +1,30 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation     Test loop_multircv -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource          ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+${FIRST_REGEX} =    SEPARATOR=
+...    cycles/event:\\s*[0-9]+\\.[0-9]+\\s*Mevents/s/core:\\s*[0-9]+\\.[0-9]+
+...    \\s*[0-9]+\\s*MHz\\s*core[0-9]+\\s*[0-9]+
+
+# Regex pattern that must be matched by all the test cases
+@{REGEX_MATCH} =
+...    ${FIRST_REGEX}
+...    Done\\s*-\\s*exit
+
+
+*** Test Cases ***
+Test loop_multircv -c ${CORE_MASK} -${APPLICATION_MODE}
+    [Documentation]    loop_multircv -c ${CORE_MASK} -${APPLICATION_MODE}
+    [Tags]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=40    regex_match=${REGEX_MATCH}

--- a/robot-tests/performance/pairs.robot
+++ b/robot-tests/performance/pairs.robot
@@ -1,0 +1,29 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Pairs -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+${FIRST_REGEX} =    SEPARATOR=
+...    cycles/event:\\s*[0-9]+\\.[0-9]+\\s*Mevents/s/core:\\s*[0-9]+\\.[0-9]+
+...    \\s*[0-9]+\\s*MHz\\s*core[0-9]+\\s*[0-9]+
+
+@{REGEX_MATCH} =
+...    ${FIRST_REGEX}
+...    Done\\s*-\\s*exit
+
+
+*** Test Cases ***
+Test Pairs
+    [Documentation]    pairs -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=30    regex_match=${REGEX_MATCH}

--- a/robot-tests/performance/queue_groups.robot
+++ b/robot-tests/performance/queue_groups.robot
@@ -1,0 +1,28 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Queue Group -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+${FIRST_REGEX} =    SEPARATOR=
+...    Cycles/Event:\\s*[0-9]+\\s*Events/s:\\s*[0-9]+\\.[0-9]+\\s*M\\s*Latency:
+...    \\s*Hi-prio=[0-9]+\\s*Lo-prio=[0-9]+\\s*@[0-9]+\\s*MHz\\([0-9]+\\)
+
+@{REGEX_MATCH} =
+...    ${FIRST_REGEX}
+
+
+*** Test Cases ***
+Test Queue Groups
+    [Documentation]    queue_groups -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=40    regex_match=${REGEX_MATCH}

--- a/robot-tests/performance/queues.robot
+++ b/robot-tests/performance/queues.robot
@@ -1,0 +1,31 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Queues -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+${THIRD_REGEX} =    SEPARATOR=
+...    [0-9]+\\s*[0-9]+\\.[0-9]+\\s*M\\s*[0-9]+\\s*[0-9]+\\s*[0-9]+\\s*[0-9]+
+...    \\s*[0-9]+\\s*MHz\\s*[0-9]+
+
+@{REGEX_MATCH} =
+...    Number\\s*of\\s*queues:\\s*[0-9]+
+...    Number\\s*of\\s*events:\\s*[0-9]+
+...    ${THIRD_REGEX}
+...    Done\\s*-\\s*exit
+
+
+*** Test Cases ***
+Test Queues
+    [Documentation]    queues -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=200    regex_match=${REGEX_MATCH}

--- a/robot-tests/performance/queues_local.robot
+++ b/robot-tests/performance/queues_local.robot
@@ -1,0 +1,31 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Queues Local -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+${THIRD_REGEX} =    SEPARATOR=
+...    [0-9]+\\s*[0-9]+\\.[0-9]+\\s*M\\s*[0-9]+\\s*[0-9]+\\s*[0-9]+\\s*[0-9]+
+...    \\s*[0-9]+\\s*MHz\\s*[0-9]+
+
+@{REGEX_MATCH} =
+...    Number\\s*of\\s*queues:\\s*[0-9]+
+...    Number\\s*of\\s*events:\\s*[0-9]+
+...    ${THIRD_REGEX}
+...    Done\\s*-\\s*exit
+
+
+*** Test Cases ***
+Test Queues Local
+    [Documentation]    queues_local -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=180    regex_match=${REGEX_MATCH}

--- a/robot-tests/performance/queues_unscheduled.robot
+++ b/robot-tests/performance/queues_unscheduled.robot
@@ -1,0 +1,31 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Queues Unscheduled -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+${THIRD_REGEX} =    SEPARATOR=
+...    [0-9]+\\s*[0-9]+\\s*\\.[0-9]+\\s*M\\s*[0-9]+\\s*[0-9]+\\s*[0-9]+\\s*[0-9]
+...    +\\s*[0-9]+\\s*MHz\\s*[0-9]+\\s*
+
+@{REGEX_MATCH} =
+...    Number\\s*of\\s*queues:\\s*[0-9]+\\s*\\+\\s*[0-9]+
+...    Number\\s*of\\s*events:\\s*[0-9]+\\s*\\+\\s*[0-9]+
+...    ${THIRD_REGEX}
+...    Done\\s*-\\s*exit
+
+
+*** Test Cases ***
+Test Queues Unscheduled
+    [Documentation]    queues_unscheduled -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=180    regex_match=${REGEX_MATCH}

--- a/robot-tests/performance/send_multi.robot
+++ b/robot-tests/performance/send_multi.robot
@@ -1,0 +1,31 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation    Test Send Multi -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource    ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+${THIRD_REGEX} =    SEPARATOR=
+...    [0-9]+\\s*[0-9]+\\.[0-9]+\\s*M\\s*[0-9]+\\s*[0-9]+\\s*[0-9]+\\s*[0-9]+
+...    \\s*[0-9]+\\s*MHz\\s*[0-9]+
+
+@{REGEX_MATCH} =
+...    Number\\s*of\\s*queues:\\s*[0-9]+
+...    Number\\s*of\\s*events:\\s*[0-9]+
+...    ${THIRD_REGEX}
+...    Done\\s*-\\s*exit
+
+
+*** Test Cases ***
+Queues Send Multi Test 1
+    [Documentation]    send_multi -c ${CORE_MASK} -${APPLICATION_MODE}
+    [TAGS]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=180    regex_match=${REGEX_MATCH}

--- a/robot-tests/performance/timer_periodic.robot
+++ b/robot-tests/performance/timer_periodic.robot
@@ -1,0 +1,29 @@
+*** Comments ***
+Copyright (c) 2020-2022, Nokia Solutions and Networks
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+
+*** Settings ***
+Documentation     Test timer_test_periodic -c ${CORE_MASK} -${APPLICATION_MODE}
+Resource          ../common.resource
+Test Setup        Set Log Level    TRACE
+Test Teardown     Kill Any Hanging Applications
+
+
+*** Variables ***
+# Regex pattern that must be matched by all the test cases
+@{REGEX_MATCH} =    Done\\s*-\\s*exit
+
+# Regex pattern that must not be matched by all the test cases
+@{REGEX_NOT_MATCH} =
+...    ERROR
+...    EM ERROR
+
+
+*** Test Cases ***
+Test timer_test_periodic -c ${CORE_MASK} -${APPLICATION_MODE}
+    [Documentation]    timer_test_periodic -c ${CORE_MASK} -${APPLICATION_MODE}
+    [Tags]    ${CORE_MASK}    ${APPLICATION_MODE}
+
+    Run EM-ODP Test    sleep_time=60    regex_match=${REGEX_MATCH}


### PR DESCRIPTION
Move robot tests from [ci ](https://github.com/openeventmachine/ci) repo and modify the script to run robot test accordingly.