### PR TITLE
Event Machine (EM) on ODP v3.8.0-1

### DIFF
--- a/CHANGE_NOTES
+++ b/CHANGE_NOTES
@@ -53,6 +53,18 @@ Examples:
 - See em-odp/include/event_machine/README_API for API changes
 
 --------------------------------------------------------------------------------
+Event Machine (EM) on ODP v3.8.0-1
+--------------------------------------------------------------------------------
+- Fixes:
+ - event: fix em_event_clone_part()
+   In em_event_clone_part(), when cloning an event allocated not from an
+   EM-pool, but directly from an odp-pool, the event header and the EM user area
+   was not copied correctly.
+   When using odp_packet_copy_part() to clone the event, the ODP user area is
+   not copied resulting in an invalid EM event header and EM user area.
+   This is now fixed.
+
+--------------------------------------------------------------------------------
 Event Machine (EM) on ODP v3.8.0
 --------------------------------------------------------------------------------
 - Support for EM API v3.8 (em-odp/include/),

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ([2.69])
 m4_define([em_version_api_major], [3])
 m4_define([em_version_api_minor], [8])
 m4_define([em_version_implementation], [0])
-m4_define([em_version_fix], [0])
+m4_define([em_version_fix], [1])
 
 m4_define([em_version_api], [em_version_api_major.em_version_api_minor])
 m4_define([em_version], [m4_if(m4_eval(em_version_fix), [0],

--- a/src/em_event.h
+++ b/src/em_event.h
@@ -51,7 +51,8 @@ COMPILE_TIME_ASSERT(EM_TMO_TYPE_NONE == 0,
 em_status_t event_init(void);
 void print_event_info(void);
 em_event_t pkt_clone_odp(odp_packet_t pkt, odp_pool_t pkt_pool,
-			 uint32_t offset, uint32_t size, bool is_clone_part);
+			 uint32_t offset, uint32_t size,
+			 bool clone_uarea, bool is_clone_part);
 void output_queue_track(queue_elem_t *const output_q_elem);
 void output_queue_drain(const queue_elem_t *output_q_elem);
 void output_queue_buffering_drain(void);

--- a/src/event_machine_event.c
+++ b/src/event_machine_event.c
@@ -1361,7 +1361,8 @@ static em_event_t event_clone_part(em_event_t event, em_pool_t pool/*or EM_POOL_
 		 * Not an EM-pool, e.g. event from external pktio odp-pool.
 		 * Allocate and clone pkt via ODP directly.
 		 */
-		clone_event = pkt_clone_odp(pkt, odp_pool, offset, size, is_clone_part);
+		clone_event = pkt_clone_odp(pkt, odp_pool, offset, size,
+					    clone_uarea, is_clone_part);
 		if (unlikely(clone_event == EM_EVENT_UNDEF)) {
 			INTERNAL_ERROR(EM_ERR_OPERATION_FAILED, escope,
 				       "Cloning from ext odp-pool:%" PRIu64 " failed",


### PR DESCRIPTION
Contains the following fix:
 - event: fix em_event_clone_part()

See changes in:
 - CHANGE_NOTES
 - README
 - include/event_machine/README_API